### PR TITLE
Add missing API keys to env template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,18 @@
-# copy to .env and fill with your keys
+# Copy this file to `.env` and fill in your API keys.
+#
+# YELP_API_KEY is kept for optional Yelp integrations that may exist outside
+# of this repository.
 YELP_API_KEY=
+
+# Google Places API key used by `refresh_restaurants.py` when querying
+# restaurants from Google.
 GOOGLE_API_KEY=
+
+# DoorDash API key for scraping DoorDash listings in
+# `refresh_restaurants.py`.
+DOORDASH_API_KEY=
+
+# Uber Eats API key for scraping Uber Eats listings in
+# `refresh_restaurants.py`.
+UBER_EATS_API_KEY=
 


### PR DESCRIPTION
## Summary
- document all API keys used in `refresh_restaurants.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b6c50b62c832db9e270e270acbc38