### PR TITLE
Load environment in toast leads

### DIFF
--- a/toast_leads.py
+++ b/toast_leads.py
@@ -7,6 +7,9 @@ from datetime import datetime, timezone
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import requests
+from dotenv import load_dotenv
+
+load_dotenv()
 
 try:
     from chain_blocklist import CHAIN_BLOCKLIST


### PR DESCRIPTION
## Summary
- load environment variables in toast_leads.py via `load_dotenv()`

## Testing
- `python -m py_compile toast_leads.py`

------
https://chatgpt.com/codex/tasks/task_e_683ccefaf9e4832d8a461bb553b95d28