### PR TITLE
Process toast lead rows as futures finish

### DIFF
--- a/toast_leads.py
+++ b/toast_leads.py
@@ -98,28 +98,33 @@ def main() -> None:
                     if not pid or pid in seen_ids:
                         continue
                     futures[excpool.submit(fetch_details, pid, session)] = pid
-            for fut in as_completed(futures):
-                pid = futures[fut]
-                details = fut.result()
-                if not details:
-                    continue
-                seen_ids.add(pid)
-                row = {
-                    "Business Name": details.get("name"),
-                    "Formatted Address": details.get("formatted_address"),
-                    "Place ID": pid,
-                    "Formatted Phone Number": details.get("formatted_phone_number"),
-                    "International Phone Number": details.get("international_phone_number"),
-                    "Website": details.get("website"),
-                    "Rating": details.get("rating"),
-                    "User Ratings Total": details.get("user_ratings_total"),
-                    "Business Status": details.get("business_status"),
-                    "Price Level": details.get("price_level"),
-                    "lat": details.get("geometry", {}).get("location", {}).get("lat"),
-                    "lon": details.get("geometry", {}).get("location", {}).get("lng"),
-                    "last_seen": datetime.now(timezone.utc).isoformat(),
-                }
-                new_rows.append(row)
+
+                for fut in as_completed(futures):
+                    pid = futures[fut]
+                    details = fut.result()
+                    if not details:
+                        continue
+                    seen_ids.add(pid)
+                    row = {
+                        "Business Name": details.get("name"),
+                        "Formatted Address": details.get("formatted_address"),
+                        "Place ID": pid,
+                        "Formatted Phone Number": details.get(
+                            "formatted_phone_number"
+                        ),
+                        "International Phone Number": details.get(
+                            "international_phone_number"
+                        ),
+                        "Website": details.get("website"),
+                        "Rating": details.get("rating"),
+                        "User Ratings Total": details.get("user_ratings_total"),
+                        "Business Status": details.get("business_status"),
+                        "Price Level": details.get("price_level"),
+                        "lat": details.get("geometry", {}).get("location", {}).get("lat"),
+                        "lon": details.get("geometry", {}).get("location", {}).get("lng"),
+                        "last_seen": datetime.now(timezone.utc).isoformat(),
+                    }
+                    new_rows.append(row)
             next_tok = data.get("next_page_token")
             if not next_tok:
                 break


### PR DESCRIPTION
## Summary
- handle Toast lead rows inside the ThreadPoolExecutor context

## Testing
- `python -m py_compile toast_leads.py refresh_restaurants.py chain_blocklist.py`

------
https://chatgpt.com/codex/tasks/task_e_683cd3afee44832dae4711302e774bd2