### PR TITLE
Improve opening hours formatting

### DIFF
--- a/prep_restaurants.py
+++ b/prep_restaurants.py
@@ -19,12 +19,11 @@ newest = matches[-1]
 df = pd.read_csv(newest)
 
 # ---------------------------------------------------------------------
-# 1.  UTF-8 cleanup (narrow no-break space & en-dash)
+# 1.  UTF-8 cleanup (narrow no-break space)
 # ---------------------------------------------------------------------
 df["Opening Hours"] = (
     df["Opening Hours"]
       .str.replace("\u202f", " ", regex=False)   # NARROW NO-BREAK SPACE → space
-      .str.replace("\u2013", "-", regex=False)   # EN DASH → hyphen
 )
 
 # ---------------------------------------------------------------------

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,23 @@
+import re
+
+THIN_SPACE_CHARS = '\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a'
+
+
+def normalize_hours(hours_dict: dict) -> dict:
+    """Return a clean hours dict using en-dash and explicit AM/PM."""
+    dash = ' – '
+    out = {}
+
+    for day, raw in hours_dict.items():
+        if not raw:
+            continue
+        s = re.sub(f'[{THIN_SPACE_CHARS}]', '', raw)
+        if '-' not in s:
+            out[day[:3]] = s
+            continue
+        start, end = [t.strip() for t in s.split('-', 1)]
+        ampm = re.search(r'\b(AM|PM)\b', end, re.I)
+        if ampm and not re.search(r'\b(AM|PM)\b', start, re.I):
+            start = f"{start} {ampm.group(1).upper()}"
+        out[day[:3]] = f"{start}{dash}{end.upper()}"
+    return out


### PR DESCRIPTION
## Summary
- add `normalize_hours` helper to utils
- parse and normalize Google opening hours when fetching restaurant data
- keep en-dash formatting during preparation

## Testing
- `python -m py_compile utils.py refresh_restaurants.py prep_restaurants.py toast_leads.py network_utils.py chain_blocklist.py`

------
https://chatgpt.com/codex/tasks/task_e_683d138354fc832d8bb031bbe237e1ea