### PR TITLE
Fix split_hours with null detection

### DIFF
--- a/prep_restaurants.py
+++ b/prep_restaurants.py
@@ -30,6 +30,10 @@ df["Opening Hours"] = (
 # 2.  Split opening hours into a dict per row
 # ---------------------------------------------------------------------
 def split_hours(text: str) -> dict:
+    """Parse semicolon-separated hours into a dictionary."""
+    if pd.isna(text) or not text:
+        return {}
+
     out = {}
     for segment in text.split(";"):
         if ":" not in segment:


### PR DESCRIPTION
## Summary
- gracefully handle null or empty `Opening Hours` text

## Testing
- `python -m py_compile prep_restaurants.py`

------
https://chatgpt.com/codex/tasks/task_e_683d3678c338832da9dc177cfe73bf78