### PR TITLE
Remove unused overpy import

### DIFF
--- a/refresh_restaurants.py
+++ b/refresh_restaurants.py
@@ -5,7 +5,6 @@ import math
 import requests
 import pandas as pd
 from datetime import datetime, timezone
-import overpy
 
 # -----------------------------------------------------------------------------
 # OPTIONAL DEPENDENCIES --------------------------------------------------------


### PR DESCRIPTION
## Summary
- delete overpy import from refresh_restaurants script

## Testing
- `python -m py_compile refresh_restaurants.py`
- `python -m py_compile toast_leads.py`
- `python -m py_compile prep_restaurants.py`
- `python -m py_compile yelp_enrich.py`
- `python -m py_compile network_utils.py`
- `python -m py_compile chain_blocklist.py`
- `python -m py_compile loader.py`
- `python -m py_compile utils.py`
- `python -m py_compile run_pipeline.sh` *(fails: invalid syntax since it's a shell script)*

------
https://chatgpt.com/codex/tasks/task_e_683d37bd8930832d9c47d4a7c2ad3ccb