### PR TITLE
Add pytest suite and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,11 @@ The script currently targets a single ZIP code (`98501`). Adjust `TARGET_OLYMPIA
 
 1. Run `toast_leads.py` to gather additional restaurant leads. Ensure the `GOOGLE_API_KEY` environment variable is set before running.
 2. The script outputs an `olympia_toast_smb_<timestamp>.csv` and caches processed place IDs in `seen_place_ids.json` so only new results are fetched.
+
+## Tests
+
+To run the unit tests, install pytest and execute:
+```bash
+pip install pytest
+pytest
+```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -vv

--- a/tests/test_network_utils.py
+++ b/tests/test_network_utils.py
@@ -1,0 +1,23 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import requests
+import pytest
+from network_utils import check_network
+
+
+def test_check_network_success(monkeypatch):
+    def dummy_head(url, timeout):
+        class Resp:
+            pass
+        return Resp()
+
+    monkeypatch.setattr(requests, "head", dummy_head)
+    assert check_network()
+
+
+def test_check_network_failure(monkeypatch):
+    def dummy_head(url, timeout):
+        raise requests.RequestException
+
+    monkeypatch.setattr(requests, "head", dummy_head)
+    assert not check_network()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,17 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import pytest
+from utils import normalize_hours
+
+
+def test_normalize_hours_basic():
+    hours = {
+        "Monday": "9 AM - 5 pm",
+        "Tuesday": "10-11 pm",
+        "Wednesday": "",
+    }
+    expected = {
+        "Mon": "9 AM – 5 PM",
+        "Tue": "10 PM – 11 PM",
+    }
+    assert normalize_hours(hours) == expected


### PR DESCRIPTION
## Summary
- add unit tests for `normalize_hours` and `check_network`
- configure pytest
- document running the tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d4052fe24832d98878e29c9e4f2d5