### PR TITLE
Improve network reachability check

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ This project collects restaurant information for ZIP codes around Olympia, Washi
 - **Government CSV importer** *(disabled)* for Washington health and Thurston County license data.
 - **OpenStreetMap fetcher** *(disabled)* for additional restaurant listings.
 - **Deduplication routine** that merges results from all sources while prioritizing Google Places SMB entries.
-- **Network check** to gracefully skip online fetchers when offline.
+- **Network check** using a lightweight GET request to gracefully skip online
+  fetchers when offline. Some corporate networks block HEAD requests, so the
+  check avoids them by default.
 - Output saved as `olympia_smb_google_restaurants_<timestamp>.csv`.
 - Run `prep_restaurants.py` to clean the latest CSV and write
   `restaurants_prepped.csv` and `restaurants_prepped.xlsx`.

--- a/network_utils.py
+++ b/network_utils.py
@@ -1,13 +1,29 @@
 """Utility functions for network-related checks."""
 
+import logging
 import requests
 
 
-def check_network(url: str = "https://www.google.com", timeout: int = 5) -> bool:
-    """Return True if network is reachable."""
+def check_network(
+    url: str = "https://www.google.com", timeout: int = 5, method: str = "GET"
+) -> bool:
+    """Return True if network is reachable.
+
+    A lightweight ``GET`` request is used by default as some networks block ``HEAD``
+    requests. You can override ``method`` to ``"HEAD"`` if desired or specify a
+    custom URL.
+    """
+
     try:
-        requests.head(url, timeout=timeout)
+        if method.upper() == "HEAD":
+            requests.head(url, timeout=timeout)
+        else:
+            # ``allow_redirects`` avoids downloading large responses
+            requests.get(url, timeout=timeout, allow_redirects=False)
         return True
+    except requests.exceptions.SSLError as exc:
+        logging.error("SSL error when checking %s: %s", url, exc)
+        return False
     except requests.RequestException:
         return False
 

--- a/tests/test_network_utils.py
+++ b/tests/test_network_utils.py
@@ -6,18 +6,19 @@ from network_utils import check_network
 
 
 def test_check_network_success(monkeypatch):
-    def dummy_head(url, timeout):
+    def dummy_get(url, timeout, allow_redirects):
         class Resp:
             pass
+
         return Resp()
 
-    monkeypatch.setattr(requests, "head", dummy_head)
+    monkeypatch.setattr(requests, "get", dummy_get)
     assert check_network()
 
 
 def test_check_network_failure(monkeypatch):
-    def dummy_head(url, timeout):
+    def dummy_get(url, timeout, allow_redirects):
         raise requests.RequestException
 
-    monkeypatch.setattr(requests, "head", dummy_head)
+    monkeypatch.setattr(requests, "get", dummy_get)
     assert not check_network()


### PR DESCRIPTION
## Summary
- switch `check_network` to a lightweight GET request
- log SSL errors separately
- update tests for GET-based network check
- document blocked HEAD request behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683d4130ae54832d880d231a48ee8850