### PR TITLE
Handle missing CSV gracefully in pipeline

### DIFF
--- a/run_pipeline.sh
+++ b/run_pipeline.sh
@@ -3,7 +3,7 @@ set -e
 python refresh_restaurants.py
 
 # Find the newest Google restaurants CSV if it exists
-latest=$(ls -t *_google_restaurants_*.csv 2>/dev/null | head -1)
+latest=$(ls -t *_google_restaurants_*.csv 2>/dev/null | head -1 || true)
 
 # Exit early if no new files were created
 if [[ -z "$latest" ]]; then


### PR DESCRIPTION
## Summary
- keep `set -e` from aborting when no Google restaurant CSV exists
- preserve informative error message on missing CSV

## Testing
- `pytest -q`
- `bash -c 'export GOOGLE_API_KEY=foo; ./run_pipeline.sh; echo exit=$?'`

------
https://chatgpt.com/codex/tasks/task_e_683d41f94b94832d8588b697d4be324c