### PR TITLE
Centralize configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ This project collects restaurant information for ZIP codes around Olympia, Washi
    ```bash
    pip install -r requirements.txt
    ```
-2. Copy `.env.template` to `.env` and fill in your `GOOGLE_API_KEY`. Other keys are optional.
+2. Copy `.env.template` to `.env` and fill in your `GOOGLE_API_KEY`. Other keys are optional. Configuration is loaded via `config.py`.
 3. Run the script:
    ```bash
    python refresh_restaurants.py
    ```
 
-The script currently targets a single ZIP code (`98501`). Adjust `TARGET_OLYMPIA_ZIPS` in `refresh_restaurants.py` if you need additional areas.
+The script currently targets a single ZIP code (`98501`). Adjust `TARGET_OLYMPIA_ZIPS` in `config.py` if you need additional areas.
 
 ## Toast lead enrichment
 

--- a/config.py
+++ b/config.py
@@ -1,0 +1,31 @@
+"""Central configuration for API keys and constants."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+try:
+    from dotenv import load_dotenv  # type: ignore
+except Exception:  # pragma: no cover - fallback when python-dotenv isn't installed
+    def load_dotenv(*_a: Any, **_kw: Any) -> None:
+        return None
+
+load_dotenv()
+
+GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
+YELP_API_KEY = os.getenv("YELP_API_KEY")
+DOORDASH_API_KEY = os.getenv("DOORDASH_API_KEY")
+UBER_EATS_API_KEY = os.getenv("UBER_EATS_API_KEY")
+
+_required = {"GOOGLE_API_KEY": GOOGLE_API_KEY}
+_missing = [name for name, val in _required.items() if not val]
+if _missing:
+    raise SystemExit(
+        f"Missing required env vars: {', '.join(_missing)}. "
+        "Add them to your .env or export them before running."
+    )
+
+TARGET_OLYMPIA_ZIPS = ["98501"]
+OLYMPIA_LAT = 47.0379
+OLYMPIA_LON = -122.9007

--- a/refresh_restaurants.py
+++ b/refresh_restaurants.py
@@ -1,10 +1,16 @@
-import os
 import time
 import json
 import math
 import requests
 import pandas as pd
 from datetime import datetime, timezone
+
+from config import (
+    GOOGLE_API_KEY,
+    TARGET_OLYMPIA_ZIPS,
+    OLYMPIA_LAT,
+    OLYMPIA_LON,
+)
 
 MAX_PAGES = 6   # safety cap; tweak per need
 
@@ -16,11 +22,6 @@ try:
 except ImportError:
     geocoder = None
 
-try:
-    from dotenv import load_dotenv
-except ImportError:
-    def load_dotenv(*_args, **_kwargs):
-        pass
 
 # -----------------------------------------------------------------------------
 # LOCAL MODULES ----------------------------------------------------------------
@@ -32,22 +33,14 @@ from utils import normalize_hours
 # Data store for Google Places results
 smb_restaurants_data: list[dict] = []
 
-load_dotenv()
-
 # -----------------------------------------------------------------------------
 # CONFIGURATION ----------------------------------------------------------------
 # -----------------------------------------------------------------------------
-GOOGLE_API_KEY: str | None = os.getenv("GOOGLE_API_KEY")
-if not GOOGLE_API_KEY:
-    raise SystemExit("Error: GOOGLE_API_KEY not found. Add it to your .env or export it before running.")
-
 GOV_CSV_FILES = {
     "wa_health": "wa_food_establishments.csv",
     "thurston_county": "thurston_business_licenses.csv",
 }
 OVERPASS_ENDPOINT = "https://overpass-api.de/api/interpreter"
-TARGET_OLYMPIA_ZIPS = ["98501"]  # extend this list as needed
-OLYMPIA_LAT, OLYMPIA_LON = 47.0379, -122.9007  # used for distance calculation
 
 # -----------------------------------------------------------------------------
 # UTILS ------------------------------------------------------------------------

--- a/toast_leads.py
+++ b/toast_leads.py
@@ -1,4 +1,3 @@
-import os
 import json
 import csv
 import time
@@ -11,14 +10,7 @@ import requests
 # ---------------------------------------------------------------------------
 # 0.  Setup
 # ---------------------------------------------------------------------------
-try:
-    from dotenv import load_dotenv
-except ImportError:
-    def load_dotenv(*_args, **_kwargs):
-        """Fallback if python-dotenv isn’t installed."""
-        pass
-
-load_dotenv()
+from config import GOOGLE_API_KEY, TARGET_OLYMPIA_ZIPS
 
 try:
     from chain_blocklist import CHAIN_BLOCKLIST            # names to skip
@@ -31,13 +23,8 @@ except Exception:
     def check_network() -> bool:
         return True
 
-GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
-if not GOOGLE_API_KEY:
-    raise SystemExit("Error: GOOGLE_API_KEY environment variable not set")
-
 SEARCH_URL  = "https://maps.googleapis.com/maps/api/place/textsearch/json"
 DETAILS_URL = "https://maps.googleapis.com/maps/api/place/details/json"
-TARGET_OLYMPIA_ZIPS = ["98501"]           # add more ZIPs as needed
 
 logging.basicConfig(
     filename="error.log",

--- a/yelp_enrich.py
+++ b/yelp_enrich.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import pathlib
 import sqlite3
 from typing import Any
@@ -12,16 +11,9 @@ import requests
 # --------------------------------------------------------------------------- #
 # Config & setup
 # --------------------------------------------------------------------------- #
-try:
-    from dotenv import load_dotenv  # type: ignore
-except Exception:  # pragma: no cover
-    def load_dotenv(*_a: Any, **_kw: Any) -> None:  # fallback no-op
-        pass
-
-load_dotenv()  # pull vars from .env if present
+from config import YELP_API_KEY
 
 DB_PATH = pathlib.Path(__file__).with_name("dela.sqlite")
-YELP_API_KEY = os.getenv("YELP_API_KEY")
 
 if not YELP_API_KEY:
     raise SystemExit("⚠️  Set YELP_API_KEY first (env var or .env file)")


### PR DESCRIPTION
## Summary
- add `config.py` to load environment variables and shared constants
- use new config module in `refresh_restaurants.py`, `toast_leads.py`, and `yelp_enrich.py`
- document config module in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683da6b1563c832da6c6bfa9a7cb1921