### PR TITLE
Add shared haversine_miles utility

### DIFF
--- a/prep_restaurants.py
+++ b/prep_restaurants.py
@@ -6,8 +6,8 @@ Clean Google SMB CSV and generate:
 """
 
 import glob
-import math
 import pandas as pd
+from utils import haversine_miles
 
 # ---------------------------------------------------------------------
 # 0.  Load the most-recent Google export
@@ -55,17 +55,12 @@ df["Price"] = df["Price Level"].map(price_map).fillna("")
 # ---------------------------------------------------------------------
 BX_LAT, BX_LON = 47.6154255, -122.2035954      # Bellevue Square Mall
 
-def haversine_miles(lat1, lon1, lat2=BX_LAT, lon2=BX_LON):
-    """Great-circle distance in miles."""
-    R = 3959
-    φ1, φ2 = math.radians(lat1), math.radians(lat2)
-    dφ  = math.radians(lat2 - lat1)
-    dλ  = math.radians(lon2 - lon1)
-    a = math.sin(dφ/2)**2 + math.cos(φ1)*math.cos(φ2)*math.sin(dλ/2)**2
-    return R * (2 * math.atan2(math.sqrt(a), math.sqrt(1 - a)))
-
 df["Distance Miles"] = df.apply(
-    lambda r: round(haversine_miles(r["lat"], r["lon"]), 2), axis=1
+    lambda r: round(
+        haversine_miles(r["lat"], r["lon"], BX_LAT, BX_LON),
+        2,
+    ),
+    axis=1,
 )
 
 # ---------------------------------------------------------------------

--- a/refresh_restaurants.py
+++ b/refresh_restaurants.py
@@ -1,6 +1,5 @@
 import time
 import json
-import math
 import requests
 import pandas as pd
 from datetime import datetime, timezone
@@ -28,7 +27,7 @@ except ImportError:
 # -----------------------------------------------------------------------------
 from chain_blocklist import CHAIN_BLOCKLIST  # list of substrings that ID big chains
 from network_utils import check_network
-from utils import normalize_hours
+from utils import normalize_hours, haversine_miles
 
 # Data store for Google Places results
 smb_restaurants_data: list[dict] = []
@@ -46,20 +45,8 @@ OVERPASS_ENDPOINT = "https://overpass-api.de/api/interpreter"
 # UTILS ------------------------------------------------------------------------
 # -----------------------------------------------------------------------------
 
-
-
-def haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
-    """Return great‑circle distance in miles between two lat/lon points."""
-    R = 3958.8  # Earth radius in miles
-    phi1, phi2 = math.radians(lat1), math.radians(lat2)
-    dphi = math.radians(lat2 - lat1)
-    dlambda = math.radians(lon2 - lon1)
-    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlambda / 2) ** 2
-    return 2 * R * math.atan2(math.sqrt(a), math.sqrt(1 - a))
-
-
 # -----------------------------------------------------------------------------
-# 1) GOOGLE PLACES FETCHER ------------------------------------------------------
+# 1) GOOGLE PLACES FETCHER -----------------------------------------------------
 # -----------------------------------------------------------------------------
 
 def fetch_google_places() -> None:
@@ -172,7 +159,13 @@ def fetch_google_places() -> None:
                     # distance from Olympia center
                     if basic_row["lat"] is not None and basic_row["lon"] is not None:
                         enriched["Distance Miles"] = round(
-                            haversine(OLYMPIA_LAT, OLYMPIA_LON, basic_row["lat"], basic_row["lon"]), 2
+                            haversine_miles(
+                                OLYMPIA_LAT,
+                                OLYMPIA_LON,
+                                basic_row["lat"],
+                                basic_row["lon"],
+                            ),
+                            2,
                         )
                     else:
                         enriched["Distance Miles"] = None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import sys, pathlib
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 import pytest
-from utils import normalize_hours
+from utils import normalize_hours, haversine_miles
 
 
 def test_normalize_hours_basic():
@@ -15,3 +15,17 @@ def test_normalize_hours_basic():
         "Tue": "10 PM – 11 PM",
     }
     assert normalize_hours(hours) == expected
+
+
+def test_haversine_zero_distance():
+    assert haversine_miles(47.0, -122.0, 47.0, -122.0) == pytest.approx(0.0)
+
+
+def test_haversine_one_degree_latitude():
+    dist = haversine_miles(47.0, -122.0, 48.0, -122.0)
+    assert dist == pytest.approx(69.09, rel=1e-2)
+
+
+def test_haversine_one_degree_longitude():
+    dist = haversine_miles(47.0, -122.0, 47.0, -123.0)
+    assert dist == pytest.approx(47.12, rel=1e-2)

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,17 @@
 import re
+import math
 
 THIN_SPACE_CHARS = '\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a'
+
+
+def haversine_miles(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Great‑circle distance in miles between two lat/lon points."""
+    R = 3958.8
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    dphi = math.radians(lat2 - lat1)
+    dlambda = math.radians(lon2 - lon1)
+    a = math.sin(dphi / 2) ** 2 + math.cos(phi1) * math.cos(phi2) * math.sin(dlambda / 2) ** 2
+    return 2 * R * math.atan2(math.sqrt(a), math.sqrt(1 - a))
 
 
 def normalize_hours(hours_dict: dict) -> dict:


### PR DESCRIPTION
## Summary
- share haversine_miles function in utils
- use haversine_miles in refresh_restaurants and prep_restaurants
- expand unit tests for haversine_miles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dcc3c4678832da26d9892649ed2ae