### PR TITLE
Handle None/NaN in haversine distance

### DIFF
--- a/prep_restaurants.py
+++ b/prep_restaurants.py
@@ -55,13 +55,11 @@ df["Price"] = df["Price Level"].map(price_map).fillna("")
 # ---------------------------------------------------------------------
 BX_LAT, BX_LON = 47.6154255, -122.2035954      # Bellevue Square Mall
 
-df["Distance Miles"] = df.apply(
-    lambda r: round(
-        haversine_miles(r["lat"], r["lon"], BX_LAT, BX_LON),
-        2,
-    ),
-    axis=1,
-)
+def _bx_distance(row):
+    dist = haversine_miles(row["lat"], row["lon"], BX_LAT, BX_LON)
+    return round(dist, 2) if dist is not None else None
+
+df["Distance Miles"] = df.apply(_bx_distance, axis=1)
 
 # ---------------------------------------------------------------------
 # 5.  Quick lead-quality flags

--- a/refresh_restaurants.py
+++ b/refresh_restaurants.py
@@ -157,18 +157,13 @@ def fetch_google_places() -> None:
                     }
 
                     # distance from Olympia center
-                    if basic_row["lat"] is not None and basic_row["lon"] is not None:
-                        enriched["Distance Miles"] = round(
-                            haversine_miles(
-                                OLYMPIA_LAT,
-                                OLYMPIA_LON,
-                                basic_row["lat"],
-                                basic_row["lon"],
-                            ),
-                            2,
-                        )
-                    else:
-                        enriched["Distance Miles"] = None
+                    dist = haversine_miles(
+                        OLYMPIA_LAT,
+                        OLYMPIA_LON,
+                        basic_row["lat"],
+                        basic_row["lon"],
+                    )
+                    enriched["Distance Miles"] = round(dist, 2) if dist is not None else None
 
                     # final row
                     smb_restaurants_data.append(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import sys, pathlib
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 import pytest
+import math
 from utils import normalize_hours, haversine_miles
 
 
@@ -29,3 +30,14 @@ def test_haversine_one_degree_latitude():
 def test_haversine_one_degree_longitude():
     dist = haversine_miles(47.0, -122.0, 47.0, -123.0)
     assert dist == pytest.approx(47.12, rel=1e-2)
+
+
+def test_haversine_invalid_none():
+    assert haversine_miles(None, -122.0, 47.0, -123.0) is None
+    assert haversine_miles(47.0, None, 47.0, -123.0) is None
+
+
+def test_haversine_invalid_nan():
+    nan = math.nan
+    assert haversine_miles(nan, -122.0, 47.0, -123.0) is None
+    assert haversine_miles(47.0, nan, 47.0, -123.0) is None

--- a/utils.py
+++ b/utils.py
@@ -4,8 +4,16 @@ import math
 THIN_SPACE_CHARS = '\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a'
 
 
-def haversine_miles(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
-    """Great‑circle distance in miles between two lat/lon points."""
+def haversine_miles(lat1: float, lon1: float, lat2: float, lon2: float):
+    """Great‑circle distance in miles between two lat/lon points.
+
+    Returns ``None`` if any coordinate is ``None`` or NaN.
+    """
+
+    for v in (lat1, lon1, lat2, lon2):
+        if v is None or math.isnan(v):
+            return None
+
     R = 3958.8
     phi1, phi2 = math.radians(lat1), math.radians(lat2)
     dphi = math.radians(lat2 - lat1)


### PR DESCRIPTION
## Summary
- allow `haversine_miles` to return `None` when any coordinate is `None` or NaN
- propagate `None` distance through `refresh_restaurants.py` and `prep_restaurants.py`
- expand tests for the new cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dceee452c832d9b50f71060a363c6