### PR TITLE
Add network check to Yelp enrichment

### DIFF
--- a/tests/test_yelp_enrich.py
+++ b/tests/test_yelp_enrich.py
@@ -1,0 +1,22 @@
+import sys, pathlib
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import os
+import sqlite3
+
+
+def test_enrich_exits_without_network(tmp_path, monkeypatch):
+    os.environ["YELP_API_KEY"] = "TEST"
+    import yelp_enrich
+    tmp_db = tmp_path / "dela.sqlite"
+    tmp_db.touch()
+    monkeypatch.setattr(yelp_enrich, "DB_PATH", tmp_db)
+    monkeypatch.setattr(yelp_enrich, "check_network", lambda: False)
+
+    called = []
+    def dummy_connect(path):
+        called.append(path)
+        raise AssertionError("connect should not be called")
+    monkeypatch.setattr(sqlite3, "connect", dummy_connect)
+
+    yelp_enrich.enrich()
+    assert called == []

--- a/yelp_enrich.py
+++ b/yelp_enrich.py
@@ -8,6 +8,8 @@ from typing import Any
 
 import requests
 
+from network_utils import check_network
+
 # --------------------------------------------------------------------------- #
 # Config & setup
 # --------------------------------------------------------------------------- #
@@ -27,6 +29,10 @@ SEARCH_URL = "https://api.yelp.com/v3/businesses/search"
 def enrich() -> None:
     if not DB_PATH.exists():
         raise SystemExit(f"Database not found: {DB_PATH}")
+
+    if not check_network():
+        print("[WARN] Yelp enrichment skipped – network unreachable.")
+        return
 
     conn = sqlite3.connect(DB_PATH)
     cur = conn.cursor()


### PR DESCRIPTION
## Summary
- call `check_network` at the start of `yelp_enrich.enrich`
- exit early with a warning when network is unreachable
- test early exit behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dd2768a20832db79ae60cd6cec86f