### PR TITLE
Add venue category support

### DIFF
--- a/restaurants/loader.py
+++ b/restaurants/loader.py
@@ -33,6 +33,8 @@ CREATE TABLE IF NOT EXISTS places (
   intl_phone TEXT,
   website TEXT,
   photo_ref TEXT,
+  categories TEXT,
+  category TEXT,
   distance_miles REAL,
   source TEXT,
   first_seen TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -61,6 +63,8 @@ RENAMES = {
     "International Phone Number": "intl_phone",
     "Website": "website",
     "Photo Reference": "photo_ref",
+    "Types": "categories",
+    "Category": "category",
     "Distance Miles": "distance_miles",
     "source": "source"
 }
@@ -71,7 +75,16 @@ RENAMES = {
 def ensure_db() -> sqlite3.Connection:
     """Create dela.sqlite and the places table if they don’t exist yet."""
     conn = sqlite3.connect(DB_PATH)
-    conn.executescript(SCHEMA)
+    cur = conn.cursor()
+    cur.execute("PRAGMA table_info(places)")
+    cols = {row[1] for row in cur.fetchall()}
+    if not cols:
+        conn.executescript(SCHEMA)
+    else:
+        if "categories" not in cols:
+            cur.execute("ALTER TABLE places ADD COLUMN categories TEXT")
+        if "category" not in cols:
+            cur.execute("ALTER TABLE places ADD COLUMN category TEXT")
     conn.commit()
     return conn
 

--- a/restaurants/refresh_restaurants.py
+++ b/restaurants/refresh_restaurants.py
@@ -160,6 +160,7 @@ def fetch_google_places() -> None:
                         ),
                         "Price Level": details.get("price_level"),
                         "Types": ",".join(details.get("types", [])),
+                        "Category": (details.get("types") or [None])[0],
                         "Photo Reference": photos[0].get("photo_reference") if photos else None,
                         "Street Address": street,
                         "City": _ac("locality"),

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,25 @@
+import csv
+import sqlite3
+from restaurants import loader
+
+
+def test_loader_inserts_category(tmp_path, monkeypatch):
+    csv_path = tmp_path / "sample.csv"
+    fields = list(loader.RENAMES.keys())
+    with csv_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        row = {field: "x" for field in fields}
+        row["Place ID"] = "pid1"
+        row["Types"] = "bar,cafe"
+        row["Category"] = "bar"
+        writer.writerow(row)
+
+    tmp_db = tmp_path / "dela.sqlite"
+    monkeypatch.setattr(loader, "DB_PATH", tmp_db)
+    loader.load(csv_path)
+
+    conn = sqlite3.connect(tmp_db)
+    res = conn.execute("SELECT categories, category FROM places").fetchone()
+    conn.close()
+    assert res == ("bar,cafe", "bar")


### PR DESCRIPTION
## Summary
- keep venue categories from Google Places results
- insert `categories` and `category` columns into the sqlite database
- expose venue category in the data refresh script
- test loader category support

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_683de420cacc832da4f1ba63759a3e79