### PR TITLE
Add Yelp cuisine columns to loader

### DIFF
--- a/restaurants/loader.py
+++ b/restaurants/loader.py
@@ -45,7 +45,9 @@ CREATE TABLE IF NOT EXISTS places (
   yelp_rating REAL,
   yelp_reviews INTEGER,
   yelp_price_tier TEXT,
-  yelp_status TEXT
+  yelp_status TEXT,
+  yelp_cuisines TEXT,
+  yelp_primary_cuisine TEXT
 );
 """)
 
@@ -86,6 +88,10 @@ def ensure_db() -> sqlite3.Connection:
         cur.execute("ALTER TABLE places ADD COLUMN categories TEXT")
     if "category" not in cols:
         cur.execute("ALTER TABLE places ADD COLUMN category TEXT")
+    if "yelp_cuisines" not in cols:
+        cur.execute("ALTER TABLE places ADD COLUMN yelp_cuisines TEXT")
+    if "yelp_primary_cuisine" not in cols:
+        cur.execute("ALTER TABLE places ADD COLUMN yelp_primary_cuisine TEXT")
     conn.commit()
     return conn
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -23,3 +23,38 @@ def test_loader_inserts_category(tmp_path, monkeypatch):
     res = conn.execute("SELECT categories, category FROM places").fetchone()
     conn.close()
     assert res == ("bar,cafe", "bar")
+
+
+def test_ensure_db_adds_yelp_columns_fresh_db(tmp_path, monkeypatch):
+    tmp_db = tmp_path / "dela.sqlite"
+    monkeypatch.setattr(loader, "DB_PATH", tmp_db)
+
+    conn = loader.ensure_db()
+    conn.close()
+
+    conn = sqlite3.connect(tmp_db)
+    cur = conn.cursor()
+    cur.execute("PRAGMA table_info(places)")
+    cols = {row[1] for row in cur.fetchall()}
+    conn.close()
+
+    assert {"yelp_cuisines", "yelp_primary_cuisine"} <= cols
+
+
+def test_ensure_db_adds_yelp_columns_existing_db(tmp_path, monkeypatch):
+    tmp_db = tmp_path / "dela.sqlite"
+    conn = sqlite3.connect(tmp_db)
+    conn.execute("CREATE TABLE places (place_id TEXT PRIMARY KEY)")
+    conn.close()
+
+    monkeypatch.setattr(loader, "DB_PATH", tmp_db)
+    conn = loader.ensure_db()
+    conn.close()
+
+    conn = sqlite3.connect(tmp_db)
+    cur = conn.cursor()
+    cur.execute("PRAGMA table_info(places)")
+    cols = {row[1] for row in cur.fetchall()}
+    conn.close()
+
+    assert {"yelp_cuisines", "yelp_primary_cuisine"} <= cols


### PR DESCRIPTION
## Summary
- extend database schema with Yelp cuisine fields
- update `ensure_db` to add missing Yelp columns
- test that new columns are created for new and existing DBs

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683deb181f94832d94e698f89a9d4e62