### PR TITLE
Update Yelp enrichment

### DIFF
--- a/restaurants/yelp_enrich.py
+++ b/restaurants/yelp_enrich.py
@@ -70,19 +70,28 @@ def enrich() -> None:
             fail += 1
             continue
 
+        cats = biz.get("categories") or []
+        aliases = [c.get("alias") for c in cats if c and c.get("alias")]
+        cuisines = ",".join(aliases) if aliases else None
+        primary_cuisine = aliases[0] if aliases else None
+
         cur.execute(
             """
             UPDATE places SET
-                yelp_rating     = ?,
-                yelp_reviews    = ?,
-                yelp_price_tier = ?,
-                yelp_status     = 'SUCCESS'
+                yelp_rating         = ?,
+                yelp_reviews        = ?,
+                yelp_price_tier     = ?,
+                yelp_cuisines       = ?,
+                yelp_primary_cuisine= ?,
+                yelp_status         = 'SUCCESS'
             WHERE place_id = ?
             """,
             (
                 biz.get("rating"),
                 biz.get("review_count"),
                 biz.get("price"),
+                cuisines,
+                primary_cuisine,
                 place_id,
             ),
         )

--- a/tests/test_yelp_enrich.py
+++ b/tests/test_yelp_enrich.py
@@ -18,3 +18,56 @@ def test_enrich_exits_without_network(tmp_path, monkeypatch):
 
     yelp_enrich.enrich()
     assert called == []
+
+
+def test_enrich_inserts_categories(tmp_path, monkeypatch):
+    os.environ["YELP_API_KEY"] = "TEST"
+    from restaurants import loader, yelp_enrich
+
+    tmp_db = tmp_path / "dela.sqlite"
+    monkeypatch.setattr(loader, "DB_PATH", tmp_db)
+    conn = loader.ensure_db()
+    conn.execute(
+        "INSERT INTO places (place_id, name, city, state, lat, lon) VALUES (?,?,?,?,?,?)",
+        ("pid1", "Foo", "Olympia", "WA", 47.0, -122.0),
+    )
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(yelp_enrich, "DB_PATH", tmp_db)
+    monkeypatch.setattr(yelp_enrich, "check_network", lambda: True)
+
+    def dummy_get(url, headers, params, timeout):
+        class Resp:
+            @staticmethod
+            def raise_for_status():
+                pass
+
+            @staticmethod
+            def json():
+                return {
+                    "businesses": [
+                        {
+                            "rating": 4.0,
+                            "review_count": 20,
+                            "price": "$$",
+                            "categories": [
+                                {"alias": "pizza", "title": "Pizza"},
+                                {"alias": "italian", "title": "Italian"},
+                            ],
+                        }
+                    ]
+                }
+
+        return Resp()
+
+    monkeypatch.setattr(yelp_enrich.requests, "get", dummy_get)
+
+    yelp_enrich.enrich()
+
+    conn = sqlite3.connect(tmp_db)
+    row = conn.execute(
+        "SELECT yelp_cuisines, yelp_primary_cuisine FROM places WHERE place_id='pid1'"
+    ).fetchone()
+    conn.close()
+    assert row == ("pizza,italian", "pizza")


### PR DESCRIPTION
## Summary
- capture Yelp categories and save them to the DB
- record the primary cuisine in addition to all cuisines
- add tests for cuisine enrichment

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683dec5b65d4832dadfade17421c3985