### PR TITLE
Add Yelp enrichment tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+import pathlib
+
+# Add repository root to sys.path for tests
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -58,3 +58,22 @@ def test_ensure_db_adds_yelp_columns_existing_db(tmp_path, monkeypatch):
     conn.close()
 
     assert {"yelp_cuisines", "yelp_primary_cuisine"} <= cols
+
+
+def test_ensure_db_updates_partial_schema(tmp_path, monkeypatch):
+    """Ensure missing Yelp columns are added to an existing DB."""
+    tmp_db = tmp_path / "dela.sqlite"
+    conn = sqlite3.connect(tmp_db)
+    conn.execute(
+        "CREATE TABLE places (place_id TEXT PRIMARY KEY, name TEXT, category TEXT)"
+    )
+    conn.close()
+
+    monkeypatch.setattr(loader, "DB_PATH", tmp_db)
+    conn = loader.ensure_db()
+    conn.close()
+
+    conn = sqlite3.connect(tmp_db)
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(places)")}
+    conn.close()
+    assert {"yelp_cuisines", "yelp_primary_cuisine"} <= cols

--- a/tests/test_yelp_enrich.py
+++ b/tests/test_yelp_enrich.py
@@ -67,7 +67,8 @@ def test_enrich_inserts_categories(tmp_path, monkeypatch):
 
     conn = sqlite3.connect(tmp_db)
     row = conn.execute(
-        "SELECT yelp_cuisines, yelp_primary_cuisine FROM places WHERE place_id='pid1'"
+        "SELECT yelp_cuisines, yelp_primary_cuisine, yelp_status "
+        "FROM places WHERE place_id='pid1'"
     ).fetchone()
     conn.close()
-    assert row == ("pizza,italian", "pizza")
+    assert row == ("pizza,italian", "pizza", "SUCCESS")


### PR DESCRIPTION
## Summary
- ensure tests can import the package by adding `conftest.py`
- extend loader tests to cover updating an existing schema
- check Yelp enrichment marks a place as `SUCCESS`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ded705420832d982cacbb825c3e65