### PR TITLE
Clarify test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,14 @@ The script currently targets a single ZIP code (`98501`). Adjust `TARGET_OLYMPIA
 
 ## Tests
 
-To run the unit tests, install pytest and execute:
+Ensure the `restaurants` package is importable before running the tests. The
+simplest approach is to install the project in editable mode:
+
 ```bash
+pip install -e .
 pip install pytest
 pytest
 ```
+
+Alternatively you can adjust `PYTHONPATH` so the `restaurants` imports in the
+tests resolve.


### PR DESCRIPTION
## Summary
- document that the tests need the `restaurants` package in the path
- suggest using `pip install -e .` before running pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683deea297cc832dbc5cf8a61866abe6