### PR TITLE
Fix fallback check_network import

### DIFF
--- a/restaurants/refresh_restaurants.py
+++ b/restaurants/refresh_restaurants.py
@@ -29,6 +29,7 @@ except Exception:  # pragma: no cover - fallback for running as script
         OLYMPIA_LON,
     )
     from chain_blocklist import CHAIN_BLOCKLIST  # list of substrings that ID big chains
+    from network_utils import check_network
 MAX_PAGES = 6   # safety cap; tweak per need
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- include check_network in fallback import block

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e01703b40832dbde991e4564aca73