### PR TITLE
Update run_pipeline entrypoint

### DIFF
--- a/run_pipeline.sh
+++ b/run_pipeline.sh
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
 set -e
-python refresh_restaurants.py
+# Run the refresh-restaurants entry point. If the package is installed, you can
+# use `refresh-restaurants` directly. Running via `python -m` ensures it works
+# from a source checkout as well.
+python -m restaurants.refresh_restaurants "$@"


### PR DESCRIPTION
## Summary
- run refresh pipeline via `python -m restaurants.refresh_restaurants`
- keep script executable and document using the entry point

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e067eb018832dbed3e1fb538dd1ea