### PR TITLE
Add rapidfuzz skip in Yelp tests

### DIFF
--- a/tests/test_yelp_enrich.py
+++ b/tests/test_yelp_enrich.py
@@ -1,5 +1,8 @@
 import os
 import sqlite3
+import pytest
+
+pytest.importorskip("rapidfuzz")
 
 
 def test_enrich_exits_without_network(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- skip Yelp enrichment tests when rapidfuzz isn't installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e0715e51c832d8c6567bd430e30f6