### PR TITLE
Add Yelp category title support

### DIFF
--- a/restaurants/loader.py
+++ b/restaurants/loader.py
@@ -47,7 +47,8 @@ CREATE TABLE IF NOT EXISTS places (
   yelp_price_tier TEXT,
   yelp_status TEXT,
   yelp_cuisines TEXT,
-  yelp_primary_cuisine TEXT
+  yelp_primary_cuisine TEXT,
+  yelp_category_titles TEXT
 );
 """)
 
@@ -92,6 +93,8 @@ def ensure_db() -> sqlite3.Connection:
         cur.execute("ALTER TABLE places ADD COLUMN yelp_cuisines TEXT")
     if "yelp_primary_cuisine" not in cols:
         cur.execute("ALTER TABLE places ADD COLUMN yelp_primary_cuisine TEXT")
+    if "yelp_category_titles" not in cols:
+        cur.execute("ALTER TABLE places ADD COLUMN yelp_category_titles TEXT")
     conn.commit()
     return conn
 

--- a/restaurants/yelp_enrich.py
+++ b/restaurants/yelp_enrich.py
@@ -1,4 +1,4 @@
-"""Add Yelp ratings, review counts, and price tiers to rows in dela.sqlite."""
+"""Add Yelp ratings, review counts, price tiers, and categories to dela.sqlite."""
 
 from __future__ import annotations
 
@@ -84,8 +84,10 @@ def enrich() -> None:
 
         cats = biz.get("categories") or []
         aliases = [c.get("alias") for c in cats if c and c.get("alias")]
+        titles = [c.get("title") for c in cats if c and c.get("title")]
         cuisines = ",".join(aliases) if aliases else None
         primary_cuisine = aliases[0] if aliases else None
+        category_titles = ",".join(titles) if titles else None
 
         cur.execute(
             """
@@ -95,6 +97,7 @@ def enrich() -> None:
                 yelp_price_tier     = ?,
                 yelp_cuisines       = ?,
                 yelp_primary_cuisine= ?,
+                yelp_category_titles= ?,
                 yelp_status         = 'SUCCESS'
             WHERE place_id = ?
             """,
@@ -104,6 +107,7 @@ def enrich() -> None:
                 biz.get("price"),
                 cuisines,
                 primary_cuisine,
+                category_titles,
                 place_id,
             ),
         )

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -38,7 +38,7 @@ def test_ensure_db_adds_yelp_columns_fresh_db(tmp_path, monkeypatch):
     cols = {row[1] for row in cur.fetchall()}
     conn.close()
 
-    assert {"yelp_cuisines", "yelp_primary_cuisine"} <= cols
+    assert {"yelp_cuisines", "yelp_primary_cuisine", "yelp_category_titles"} <= cols
 
 
 def test_ensure_db_adds_yelp_columns_existing_db(tmp_path, monkeypatch):
@@ -57,7 +57,7 @@ def test_ensure_db_adds_yelp_columns_existing_db(tmp_path, monkeypatch):
     cols = {row[1] for row in cur.fetchall()}
     conn.close()
 
-    assert {"yelp_cuisines", "yelp_primary_cuisine"} <= cols
+    assert {"yelp_cuisines", "yelp_primary_cuisine", "yelp_category_titles"} <= cols
 
 
 def test_ensure_db_updates_partial_schema(tmp_path, monkeypatch):
@@ -76,4 +76,4 @@ def test_ensure_db_updates_partial_schema(tmp_path, monkeypatch):
     conn = sqlite3.connect(tmp_db)
     cols = {row[1] for row in conn.execute("PRAGMA table_info(places)")}
     conn.close()
-    assert {"yelp_cuisines", "yelp_primary_cuisine"} <= cols
+    assert {"yelp_cuisines", "yelp_primary_cuisine", "yelp_category_titles"} <= cols

--- a/tests/test_yelp_enrich.py
+++ b/tests/test_yelp_enrich.py
@@ -76,11 +76,11 @@ def test_enrich_inserts_categories(tmp_path, monkeypatch):
 
     conn = sqlite3.connect(tmp_db)
     row = conn.execute(
-        "SELECT yelp_cuisines, yelp_primary_cuisine, yelp_status "
+        "SELECT yelp_cuisines, yelp_primary_cuisine, yelp_category_titles, yelp_status "
         "FROM places WHERE place_id='pid1'"
     ).fetchone()
     conn.close()
-    assert row == ("pizza,italian", "pizza", "SUCCESS")
+    assert row == ("pizza,italian", "pizza", "Pizza,Italian", "SUCCESS")
     assert called_params.get("limit") == 5
 
 
@@ -237,6 +237,6 @@ def test_enrich_retries_missing_categories(tmp_path, monkeypatch):
     yelp_enrich.enrich()
 
     row = sqlite3.connect(tmp_db).execute(
-        "SELECT yelp_cuisines, yelp_primary_cuisine FROM places WHERE place_id='pid3'"
+        "SELECT yelp_cuisines, yelp_primary_cuisine, yelp_category_titles FROM places WHERE place_id='pid3'"
     ).fetchone()
-    assert row == ("thai", "thai")
+    assert row == ("thai", "thai", "Thai")


### PR DESCRIPTION
## Summary
- expand DB schema with `yelp_category_titles`
- persist category titles during Yelp enrichment
- adapt schema migration logic
- update tests for new column

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_683e29dfd618832da91cd8f590251c33