### PR TITLE
Add Yelp fetcher with CLI and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ Each matched Yelp business includes a list of food categories. Their aliases
 comma‑separated string, with the first alias stored separately as
 `yelp_primary_cuisine`.
 
+To fetch Yelp business data directly for a given ZIP code run:
+
+```bash
+python -m restaurants.yelp_fetch <zip>
+```
+This writes `yelp_businesses_<zip>_<timestamp>.json` with the search results,
+business details and reviews.
+
 ## Tests
 
 Ensure the `restaurants` package is importable before running the tests. The

--- a/restaurants/yelp_fetch.py
+++ b/restaurants/yelp_fetch.py
@@ -1,0 +1,131 @@
+"""Fetch Yelp restaurant data for a ZIP code."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import pathlib
+from datetime import datetime
+from typing import Any
+
+import requests
+
+try:
+    from restaurants.config import YELP_API_KEY
+    from restaurants.network_utils import check_network
+    from restaurants.utils import setup_logging
+except Exception:  # pragma: no cover - fallback for running as script
+    from config import YELP_API_KEY
+    from network_utils import check_network
+    try:
+        from utils import setup_logging
+    except Exception:  # pragma: no cover - fallback if utils missing
+        def setup_logging(level: int = logging.INFO) -> None:
+            logging.basicConfig(level=level)
+
+
+if not YELP_API_KEY:
+    raise SystemExit("\u26a0\ufe0f  Set YELP_API_KEY first (env var or .env file)")
+
+HEADERS = {"Authorization": f"Bearer {YELP_API_KEY}"}
+SEARCH_URL = "https://api.yelp.com/v3/businesses/search"
+DETAILS_URL = "https://api.yelp.com/v3/businesses/{id}"
+REVIEWS_URL = "https://api.yelp.com/v3/businesses/{id}/reviews"
+
+
+def search_yelp_businesses(
+    zip_code: str, session: requests.Session, limit: int = 50
+) -> list[dict[str, Any]]:
+    """Return all Yelp businesses for ``zip_code`` handling pagination."""
+    results: list[dict[str, Any]] = []
+    offset = 0
+    while True:
+        params = {
+            "location": zip_code,
+            "categories": "restaurants",
+            "limit": limit,
+            "offset": offset,
+        }
+        try:
+            resp = session.get(
+                SEARCH_URL, headers=HEADERS, params=params, timeout=10
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as exc:  # pragma: no cover - network errors
+            logging.error("Search failed for %s offset %s: %s", zip_code, offset, exc)
+            break
+        page_results = data.get("businesses") or []
+        results.extend(page_results)
+        total = data.get("total", len(results))
+        offset += limit
+        if offset >= total or not page_results:
+            break
+    return results
+
+
+def get_business_details(business_id: str, session: requests.Session) -> dict:
+    """Return Yelp details for ``business_id``."""
+    try:
+        resp = session.get(
+            DETAILS_URL.format(id=business_id), headers=HEADERS, timeout=10
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as exc:  # pragma: no cover - network errors
+        logging.error("Details failed for %s: %s", business_id, exc)
+        return {}
+
+
+def get_business_reviews(business_id: str, session: requests.Session) -> dict:
+    """Return Yelp reviews for ``business_id``."""
+    try:
+        resp = session.get(
+            REVIEWS_URL.format(id=business_id), headers=HEADERS, timeout=10
+        )
+        resp.raise_for_status()
+        return resp.json()
+    except Exception as exc:  # pragma: no cover - network errors
+        logging.error("Reviews failed for %s: %s", business_id, exc)
+        return {}
+
+
+def enrich_restaurants(zip_code: str) -> list[dict[str, Any]]:
+    """Return Yelp business info with details and reviews for ``zip_code``."""
+    if not check_network():
+        logging.info("Skipping Yelp fetch – network unreachable.")
+        return []
+
+    with requests.Session() as session:
+        businesses = search_yelp_businesses(zip_code, session)
+        enriched: list[dict[str, Any]] = []
+        for biz in businesses:
+            biz_id = biz.get("id")
+            if not biz_id:
+                continue
+            details = get_business_details(biz_id, session)
+            reviews = get_business_reviews(biz_id, session)
+            enriched.append({"business": biz, "details": details, "reviews": reviews})
+        return enriched
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Fetch Yelp restaurant data")
+    parser.add_argument("zip", help="ZIP code to query")
+    args = parser.parse_args(argv)
+
+    setup_logging()
+    results = enrich_restaurants(args.zip)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    out_file = pathlib.Path(f"yelp_businesses_{args.zip}_{timestamp}.json")
+    if results:
+        with out_file.open("w", encoding="utf-8") as f:
+            json.dump(results, f, indent=2)
+        logging.info("Saved %s businesses to %s", len(results), out_file)
+    else:
+        logging.info("No data fetched.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_yelp_fetch.py
+++ b/tests/test_yelp_fetch.py
@@ -1,0 +1,65 @@
+import os
+import json
+import importlib
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+
+def test_search_yelp_businesses_paginates(monkeypatch):
+    os.environ["YELP_API_KEY"] = "TEST"
+    yf = importlib.import_module("restaurants.yelp_fetch")
+
+    calls = []
+
+    class DummyResp:
+        def __init__(self, data):
+            self._data = data
+
+        @staticmethod
+        def raise_for_status():
+            pass
+
+        def json(self):
+            return self._data
+
+    class DummySession:
+        def get(self, url, headers=None, params=None, timeout=None):
+            calls.append(params.get("offset"))
+            if params.get("offset") == 0:
+                return DummyResp({"businesses": [{"id": "a"}, {"id": "b"}], "total": 3})
+            elif params.get("offset") == 2:
+                return DummyResp({"businesses": [{"id": "c"}], "total": 3})
+            else:
+                return DummyResp({"businesses": [], "total": 3})
+
+    session = DummySession()
+    results = yf.search_yelp_businesses("98501", session, limit=2)
+    assert [b["id"] for b in results] == ["a", "b", "c"]
+    assert calls == [0, 2]
+
+
+def test_cli_writes_json(tmp_path, monkeypatch):
+    os.environ["YELP_API_KEY"] = "TEST"
+    yf = importlib.import_module("restaurants.yelp_fetch")
+
+    monkeypatch.setattr(yf, "enrich_restaurants", lambda zip: [{"id": "x"}])
+    monkeypatch.setattr(yf, "setup_logging", lambda *a, **kw: None)
+
+    class FixedDatetime(datetime):
+        @classmethod
+        def now(cls):
+            return cls(2023, 1, 2, 3, 4, 5)
+
+    monkeypatch.setattr(yf, "datetime", FixedDatetime)
+
+    monkeypatch.chdir(tmp_path)
+    yf.main(["12345"])
+
+    files = list(Path(tmp_path).glob("yelp_businesses_12345_*.json"))
+    assert len(files) == 1
+    with files[0].open() as f:
+        data = json.load(f)
+    assert data == [{"id": "x"}]
+


### PR DESCRIPTION
## Summary
- add a standalone `yelp_fetch.py` module for downloading Yelp data
- document the new command in the README
- test search pagination logic and CLI JSON output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e542918f4832d895e5728fa2225fd