### PR TITLE
Add Yelp fetch tests with monkeypatch

### DIFF
--- a/tests/test_yelp_fetch.py
+++ b/tests/test_yelp_fetch.py
@@ -3,6 +3,7 @@ import json
 import importlib
 from datetime import datetime
 from pathlib import Path
+import requests
 
 import pytest
 
@@ -24,20 +25,66 @@ def test_search_yelp_businesses_paginates(monkeypatch):
         def json(self):
             return self._data
 
-    class DummySession:
-        def get(self, url, headers=None, params=None, timeout=None):
-            calls.append(params.get("offset"))
-            if params.get("offset") == 0:
-                return DummyResp({"businesses": [{"id": "a"}, {"id": "b"}], "total": 3})
-            elif params.get("offset") == 2:
-                return DummyResp({"businesses": [{"id": "c"}], "total": 3})
-            else:
-                return DummyResp({"businesses": [], "total": 3})
+    def dummy_get(url, headers=None, params=None, timeout=None):
+        calls.append(params.get("offset"))
+        if params.get("offset") == 0:
+            return DummyResp({"businesses": [{"id": "a"}, {"id": "b"}], "total": 3})
+        elif params.get("offset") == 2:
+            return DummyResp({"businesses": [{"id": "c"}], "total": 3})
+        else:
+            return DummyResp({"businesses": [], "total": 3})
 
-    session = DummySession()
+    def dummy_session_get(self, url, headers=None, params=None, timeout=None):
+        return dummy_get(url, headers=headers, params=params, timeout=timeout)
+
+    monkeypatch.setattr(requests, "get", dummy_get)
+    monkeypatch.setattr(requests.sessions.Session, "get", dummy_session_get)
+
+    session = requests.Session()
     results = yf.search_yelp_businesses("98501", session, limit=2)
     assert [b["id"] for b in results] == ["a", "b", "c"]
     assert calls == [0, 2]
+
+
+def test_enrich_restaurants_aggregates(monkeypatch):
+    os.environ["YELP_API_KEY"] = "TEST"
+    yf = importlib.import_module("restaurants.yelp_fetch")
+
+    class DummyResp:
+        def __init__(self, data):
+            self._data = data
+
+        @staticmethod
+        def raise_for_status():
+            pass
+
+        def json(self):
+            return self._data
+
+    def dummy_get(url, headers=None, params=None, timeout=None):
+        if url == yf.SEARCH_URL:
+            return DummyResp({"businesses": [{"id": "x"}], "total": 1})
+        if url == yf.DETAILS_URL.format(id="x"):
+            return DummyResp({"id": "x", "name": "X"})
+        if url == yf.REVIEWS_URL.format(id="x"):
+            return DummyResp({"reviews": [{"id": "r"}]})
+        raise AssertionError(f"unexpected url {url}")
+
+    def dummy_session_get(self, url, headers=None, params=None, timeout=None):
+        return dummy_get(url, headers=headers, params=params, timeout=timeout)
+
+    monkeypatch.setattr(requests, "get", dummy_get)
+    monkeypatch.setattr(requests.sessions.Session, "get", dummy_session_get)
+    monkeypatch.setattr(yf, "check_network", lambda: True)
+
+    results = yf.enrich_restaurants("98501")
+    assert results == [
+        {
+            "business": {"id": "x"},
+            "details": {"id": "x", "name": "X"},
+            "reviews": {"reviews": [{"id": "r"}]},
+        }
+    ]
 
 
 def test_cli_writes_json(tmp_path, monkeypatch):
@@ -62,4 +109,3 @@ def test_cli_writes_json(tmp_path, monkeypatch):
     with Path(os.environ["YELP_OUT"]).open() as f:
         data = json.load(f)
     assert data == [{"id": "12345"}]
-


### PR DESCRIPTION
## Summary
- update `test_yelp_fetch.py` to monkeypatch `requests.get`
- verify pagination in `search_yelp_businesses`
- ensure `enrich_restaurants` aggregates business, detail and review data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e580c417c832d81c305e17b4f6c7e