### PR TITLE
Ensure HEAD requests avoid redirects

### DIFF
--- a/restaurants/network_utils.py
+++ b/restaurants/network_utils.py
@@ -30,7 +30,9 @@ def check_network(
 
     try:
         if method.upper() == "HEAD":
-            requests.head(url, timeout=timeout)
+            # ``allow_redirects`` avoids downloading large responses and
+            # is explicitly disabled for ``HEAD`` requests as well
+            requests.head(url, timeout=timeout, allow_redirects=False)
         else:
             # ``allow_redirects`` avoids downloading large responses
             requests.get(url, timeout=timeout, allow_redirects=False)

--- a/tests/test_network_utils.py
+++ b/tests/test_network_utils.py
@@ -25,7 +25,9 @@ def test_check_network_failure(monkeypatch):
 
 
 def test_check_network_head(monkeypatch):
-    def dummy_head(url, timeout):
+    def dummy_head(url, timeout, allow_redirects):
+        assert allow_redirects is False
+
         class Resp:
             pass
 


### PR DESCRIPTION
## Summary
- disable redirects for `HEAD` requests in `check_network`
- verify `allow_redirects=False` when `HEAD` is used

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e5e8d4f88832d81848d1ceabb7560