### PR TITLE
Add vectorized haversine helper

### DIFF
--- a/restaurants/prep_restaurants.py
+++ b/restaurants/prep_restaurants.py
@@ -8,9 +8,13 @@ import logging
 import pandas as pd
 
 try:
-    from restaurants.utils import haversine_miles, setup_logging
+    from restaurants.utils import (
+        haversine_miles,
+        haversine_miles_series,
+        setup_logging,
+    )
 except Exception:  # pragma: no cover - fallback for running as script
-    from utils import haversine_miles, setup_logging
+    from utils import haversine_miles, haversine_miles_series, setup_logging
 
 
 BX_LAT, BX_LON = 47.6154255, -122.2035954  # Bellevue Square Mall
@@ -70,7 +74,9 @@ def main(argv: list[str] | None = None) -> None:
     # ------------------------------------------------------------------
     # 4.  Haversine distance to Bellevue Square Mall
     # ------------------------------------------------------------------
-    df["Distance Miles"] = df.apply(_bx_distance, axis=1)
+    df["Distance Miles"] = (
+        haversine_miles_series(df["lat"], df["lon"], BX_LAT, BX_LON).round(2)
+    )
 
     # ------------------------------------------------------------------
     # 5.  Quick lead-quality flags

--- a/tests/test_prep_restaurants.py
+++ b/tests/test_prep_restaurants.py
@@ -35,3 +35,11 @@ def test_prep_restaurants_functions(tmp_path, monkeypatch):
     assert pr.split_hours("Mon: 9-5; Tue: 10-6") == {"Mon": "9-5", "Tue": "10-6"}
     assert pr._bx_distance(pd.Series({"lat": pr.BX_LAT, "lon": pr.BX_LON})) == 0
 
+    series_dist = pr.haversine_miles_series(
+        pd.Series([pr.BX_LAT]),
+        pd.Series([pr.BX_LON]),
+        pr.BX_LAT,
+        pr.BX_LON,
+    )
+    assert series_dist.iloc[0] == 0
+


### PR DESCRIPTION
## Summary
- implement `haversine_miles_series` for vectorized distance calculations
- use new helper when preparing restaurants data
- test the helper in `test_prep_restaurants`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e6961c518832d92d1c787d7b6555a