### PR TITLE
Ensure Yelp enrichment mandatory

### DIFF
--- a/tests/test_google_yelp_enrich.py
+++ b/tests/test_google_yelp_enrich.py
@@ -1,5 +1,6 @@
 import os
 import importlib
+import pytest
 
 os.environ.setdefault("GOOGLE_API_KEY", "DUMMY")
 os.environ.setdefault("YELP_API_KEY", "DUMMY")
@@ -37,10 +38,11 @@ def test_enrich_restaurant_success(monkeypatch):
     assert res["yelp"]["business"]["id"] == "y1"
     assert res["yelp"]["details"]["name"] == "Foo Yelp"
     assert res["yelp"]["reviews"]["reviews"][0]["id"] == "r1"
+    assert res["yelp"]["summary"]["website"] is None
 
 
 def test_enrich_restaurant_no_network(monkeypatch):
     gye = importlib.import_module("restaurants.google_yelp_enrich")
     monkeypatch.setattr(gye, "check_network", lambda: False)
-    res = gye.enrich_restaurant("Foo", "Olympia WA")
-    assert res == {}
+    with pytest.raises(SystemExit):
+        gye.enrich_restaurant("Foo", "Olympia WA")


### PR DESCRIPTION
## Notes
- Adds fuzzy-matching Yelp search using name, coords or location
- Yelp enrichment now mandatory; network absence raises `SystemExit`
- Extracts key Yelp details (cuisines, website, delivery, review count)
- Updated tests for the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e6fa96c9c832db39b19acd287c319