### PR TITLE
Fix lint warnings and optimize haversine

### DIFF
--- a/restaurants/utils.py
+++ b/restaurants/utils.py
@@ -35,12 +35,11 @@ def haversine_miles_series(
 ) -> pd.Series:
     """Vectorized haversine distance in miles to a reference point."""
 
-    lat = lat_series.astype(float).to_numpy()
-    lon = lon_series.astype(float).to_numpy()
+    lat = lat_series.to_numpy(dtype=float)
+    lon = lon_series.to_numpy(dtype=float)
 
     mask = ~np.isnan(lat) & ~np.isnan(lon)
-    result = np.empty(lat.shape[0])
-    result[:] = np.nan
+    result = np.full(lat.shape[0], np.nan)
 
     if mask.any():
         R = 3958.8
@@ -51,9 +50,8 @@ def haversine_miles_series(
         a = np.sin(dphi / 2) ** 2 + np.cos(phi1) * np.cos(phi2) * np.sin(dlambda / 2) ** 2
         result[mask] = 2 * R * np.arctan2(np.sqrt(a), np.sqrt(1 - a))
 
-    series = pd.Series([None] * len(lat_series), index=lat_series.index, dtype=object)
-    for idx in np.where(mask)[0]:
-        series.iloc[idx] = result[idx]
+    series = pd.Series(result, index=lat_series.index)
+    series[~mask] = None
     return series
 
 

--- a/tests/test_network_utils.py
+++ b/tests/test_network_utils.py
@@ -1,5 +1,4 @@
 from tests import requests_stub
-import pytest
 import restaurants.network_utils as network_utils
 
 

--- a/tests/test_refresh_restaurants.py
+++ b/tests/test_refresh_restaurants.py
@@ -1,5 +1,4 @@
 import os
-import importlib
 
 os.environ.setdefault("GOOGLE_API_KEY", "DUMMY")
 


### PR DESCRIPTION
## Summary
- remove unused imports from tests
- vectorize haversine_miles_series

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683e8f505f94832da0cfd0380612ecc7