### PR TITLE
Fix stale Yelp enrichment entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ prompted to restrict the fetch to specific ZIP codes.
 
 ## Yelp enrichment
 
-Run `yelp_enrich.py` to supplement Google Places rows with Yelp ratings and
+Run `google_yelp_enrich.py` to supplement Google Places rows with Yelp ratings and
 categories. The script searches Yelp by the restaurant name and city and scans
  up to five candidates. `rapidfuzz.fuzz.token_set_ratio` picks the best match and
  only applies it when the score is at least 60 (configurable via `YELP_MATCH_THRESHOLD`). If no strong match is found and a

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
     entry_points={
         "console_scripts": [
             "refresh-restaurants=restaurants.refresh_restaurants:main",
-            "yelp-enrich=restaurants.yelp_enrich:enrich",
             "toast-leads=restaurants.toast_leads:main",
         ]
     },


### PR DESCRIPTION
## Summary
- drop `yelp-enrich` console script from setup
- update README to reference `google_yelp_enrich.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683e9325db08832dbe0e4d624cce7c2a