### PR TITLE
Fix ZIP codes docstring

### DIFF
--- a/restaurants/config.py
+++ b/restaurants/config.py
@@ -1,7 +1,7 @@
 """Central configuration for API keys and constants used in the Olympia services project.
 
 Loads API keys from environment variables and defines location-based constants for
-Olympia, WA, including ZIP накопcodes and geographic coordinates.
+Olympia, WA, including ZIP codes and geographic coordinates.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- fix typo `ZIP накопcodes` to `ZIP codes` in `restaurants/config.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ea5ff1e1c832d8eca2641701a15d5