### PR TITLE
Add optional Tkinter GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ By default `refresh_restaurants.py` iterates over the `TARGET_OLYMPIA_ZIPS`
 list in `config.py`.  You can pass `--zips 98501,98502` or enter a list when
 prompted to restrict the fetch to specific ZIP codes.
 
+## Optional GUI
+
+A minimal Tkinter interface is available for users who prefer not to run
+commands in the terminal. Launch it with:
+
+```bash
+python -m restaurants.gui
+```
+
+The window exposes buttons for the two main workflows: refreshing restaurant
+data and fetching Toast leads.
+
 ## Toast lead enrichment
 
 1. Run `toast_leads.py` to gather additional restaurant leads. Ensure the `GOOGLE_API_KEY` environment variable is set before running.

--- a/restaurants/gui.py
+++ b/restaurants/gui.py
@@ -1,0 +1,57 @@
+"""Simple Tkinter GUI for common tasks.
+
+Provides buttons to run ``refresh-restaurants`` and ``toast-leads``
+without using the command line.
+"""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import messagebox
+
+from . import refresh_restaurants, toast_leads
+
+
+def run_refresh() -> None:
+    """Run :func:`refresh_restaurants.main` and report completion."""
+    try:
+        refresh_restaurants.main([])
+        messagebox.showinfo("Refresh Complete", "Restaurant data refreshed.")
+    except Exception as exc:  # pragma: no cover - GUI feedback only
+        messagebox.showerror("Error", str(exc))
+
+
+def run_toast() -> None:
+    """Run :func:`toast_leads.main` and report completion."""
+    try:
+        toast_leads.main()
+        messagebox.showinfo("Toast Complete", "Toast leads fetched.")
+    except Exception as exc:  # pragma: no cover - GUI feedback only
+        messagebox.showerror("Error", str(exc))
+
+
+def make_gui() -> tk.Tk:
+    """Create the GUI window and return the ``Tk`` instance."""
+    root = tk.Tk()
+    root.title("Olympia Restaurants")
+
+    frame = tk.Frame(root, padx=20, pady=20)
+    frame.pack()
+
+    btn_refresh = tk.Button(frame, text="Refresh Restaurants", command=run_refresh)
+    btn_refresh.pack(fill="x")
+
+    btn_toast = tk.Button(frame, text="Fetch Toast Leads", command=run_toast)
+    btn_toast.pack(fill="x", pady=(10, 0))
+
+    return root
+
+
+def main() -> None:
+    """Launch the GUI application."""
+    root = make_gui()
+    root.mainloop()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         "console_scripts": [
             "refresh-restaurants=restaurants.refresh_restaurants:main",
             "toast-leads=restaurants.toast_leads:main",
+            "restaurants-gui=restaurants.gui:main",
         ]
     },
 )

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,0 +1,52 @@
+import types
+from restaurants import gui
+
+
+def test_make_gui(monkeypatch):
+    created = {}
+
+    class DummyTk:
+        def __init__(self):
+            created['root'] = True
+        def title(self, text):
+            created['title'] = text
+        def mainloop(self):
+            created['loop'] = True
+
+    class DummyFrame:
+        def __init__(self, master=None, **kw):
+            created['frame'] = True
+        def pack(self, *a, **kw):
+            pass
+
+    class DummyButton:
+        def __init__(self, master=None, **kw):
+            created.setdefault('widgets', []).append(kw.get('text'))
+        def pack(self, *a, **kw):
+            pass
+
+    monkeypatch.setattr(gui.tk, 'Tk', DummyTk)
+    monkeypatch.setattr(gui.tk, 'Frame', DummyFrame)
+    monkeypatch.setattr(gui.tk, 'Button', DummyButton)
+
+    root = gui.make_gui()
+    assert isinstance(root, DummyTk)
+    assert created['title'] == 'Olympia Restaurants'
+    assert created['widgets'] == ['Refresh Restaurants', 'Fetch Toast Leads']
+
+
+def test_run_refresh(monkeypatch):
+    called = {}
+    monkeypatch.setattr(gui.refresh_restaurants, 'main', lambda argv=None: called.setdefault('refresh', True))
+    monkeypatch.setattr(gui.messagebox, 'showinfo', lambda *a, **kw: called.setdefault('info', True))
+    gui.run_refresh()
+    assert called == {'refresh': True, 'info': True}
+
+
+def test_run_toast(monkeypatch):
+    called = {}
+    monkeypatch.setattr(gui.toast_leads, 'main', lambda: called.setdefault('toast', True))
+    monkeypatch.setattr(gui.messagebox, 'showinfo', lambda *a, **kw: called.setdefault('info', True))
+    gui.run_toast()
+    assert called == {'toast': True, 'info': True}
+


### PR DESCRIPTION
## Summary
- add a simple Tkinter GUI with buttons to run `refresh-restaurants` and `toast-leads`
- register `restaurants-gui` console script
- document GUI usage in README
- add tests covering the GUI helpers

## Testing
- `pip install -e .`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fa46e90c4832d84a1e370f9a08072