### PR TITLE
Add zip input and progress to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ By default `refresh_restaurants.py` iterates over the `TARGET_OLYMPIA_ZIPS`
 list in `config.py`.  You can pass `--zips 98501,98502` or enter a list when
 prompted to restrict the fetch to specific ZIP codes.
 
+## Optional GUI
+
+A small Tkinter interface is available for users who prefer not to run
+commands in the terminal. Launch it with:
+
+```bash
+python -m restaurants.gui
+```
+
+The window exposes buttons for the two main workflows: refreshing restaurant
+data and fetching Toast leads.  A field lets you supply comma‑separated ZIP
+codes for the refresh command. When running, an indeterminate progress bar
+spins and the collected row count is shown once complete. Any error raised by
+the process is displayed in a pop‑up dialog.
+
 ## Toast lead enrichment
 
 1. Run `toast_leads.py` to gather additional restaurant leads. Ensure the `GOOGLE_API_KEY` environment variable is set before running.

--- a/restaurants/gui.py
+++ b/restaurants/gui.py
@@ -1,0 +1,104 @@
+"""Simple Tkinter GUI for common tasks.
+
+Provides buttons to run ``refresh-restaurants`` and ``toast-leads``
+without using the command line.  This module also exposes a more
+featureful interface with a ZIP code entry field, a progress bar and
+basic error reporting.
+"""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import messagebox, ttk
+
+from . import refresh_restaurants, toast_leads
+
+# Widgets created by :func:`make_gui`.  They are populated at runtime and used
+# by :func:`run_refresh` to read ZIP codes and update progress information.
+zip_entry: tk.Entry | None = None
+progress_label: tk.Label | None = None
+progress_bar: ttk.Progressbar | None = None
+
+
+def run_refresh() -> None:
+    """Run :func:`refresh_restaurants.main` and report completion.
+
+    The ZIP codes are read from :data:`zip_entry` if available. Progress is
+    indicated by an indeterminate progress bar and a label displaying the final
+    number of collected entries. Any exception raised by the refresh process is
+    shown in an error dialog.
+    """
+    global zip_entry, progress_label, progress_bar
+
+    argv: list[str] = []
+    if zip_entry is not None:
+        zips = zip_entry.get().strip()
+        if zips:
+            argv = ["--zips", zips]
+
+    if progress_label is not None:
+        progress_label.config(text="Running…")
+    if progress_bar is not None:
+        progress_bar.start()
+
+    try:
+        refresh_restaurants.main(argv)
+        count = len(refresh_restaurants.smb_restaurants_data)
+        if progress_label is not None:
+            progress_label.config(text=f"Collected: {count}")
+        messagebox.showinfo("Refresh Complete", f"Collected {count} entries.")
+    except Exception as exc:  # pragma: no cover - GUI feedback only
+        if progress_label is not None:
+            progress_label.config(text="Error")
+        messagebox.showerror("Error", str(exc))
+    finally:
+        if progress_bar is not None:
+            progress_bar.stop()
+
+
+def run_toast() -> None:
+    """Run :func:`toast_leads.main` and report completion."""
+    try:
+        toast_leads.main()
+        messagebox.showinfo("Toast Complete", "Toast leads fetched.")
+    except Exception as exc:  # pragma: no cover - GUI feedback only
+        messagebox.showerror("Error", str(exc))
+
+
+def make_gui() -> tk.Tk:
+    """Create the GUI window and return the ``Tk`` instance."""
+    global zip_entry, progress_label, progress_bar
+
+    root = tk.Tk()
+    root.title("Olympia Restaurants")
+
+    frame = tk.Frame(root, padx=20, pady=20)
+    frame.pack()
+
+    tk.Label(frame, text="ZIP codes (comma separated)").pack(fill="x")
+    zip_entry = tk.Entry(frame)
+    zip_entry.pack(fill="x")
+
+    btn_refresh = tk.Button(frame, text="Refresh Restaurants", command=run_refresh)
+    btn_refresh.pack(fill="x", pady=(10, 0))
+
+    btn_toast = tk.Button(frame, text="Fetch Toast Leads", command=run_toast)
+    btn_toast.pack(fill="x")
+
+    progress_label = tk.Label(frame, text="Collected: 0")
+    progress_label.pack(fill="x", pady=(10, 0))
+
+    progress_bar = ttk.Progressbar(frame, mode="indeterminate")
+    progress_bar.pack(fill="x")
+
+    return root
+
+
+def main() -> None:
+    """Launch the GUI application."""
+    root = make_gui()
+    root.mainloop()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
         "console_scripts": [
             "refresh-restaurants=restaurants.refresh_restaurants:main",
             "toast-leads=restaurants.toast_leads:main",
+            "restaurants-gui=restaurants.gui:main",
         ]
     },
 )

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,0 +1,110 @@
+import types
+from restaurants import gui
+
+
+def test_make_gui(monkeypatch):
+    created = {}
+
+    class DummyTk:
+        def __init__(self):
+            created['root'] = True
+        def title(self, text):
+            created['title'] = text
+        def mainloop(self):
+            created['loop'] = True
+
+    class DummyFrame:
+        def __init__(self, master=None, **kw):
+            created['frame'] = True
+        def pack(self, *a, **kw):
+            pass
+
+    class DummyButton:
+        def __init__(self, master=None, **kw):
+            created.setdefault('widgets', []).append(kw.get('text'))
+        def pack(self, *a, **kw):
+            pass
+
+    class DummyLabel:
+        def __init__(self, master=None, **kw):
+            created.setdefault('widgets', []).append(kw.get('text', 'label'))
+        def pack(self, *a, **kw):
+            pass
+
+    class DummyEntry:
+        def __init__(self, master=None, **kw):
+            created.setdefault('widgets', []).append('entry')
+        def pack(self, *a, **kw):
+            pass
+        def get(self):
+            return ''
+
+    class DummyPB:
+        def __init__(self, master=None, **kw):
+            created.setdefault('widgets', []).append('progress')
+        def pack(self, *a, **kw):
+            pass
+
+    monkeypatch.setattr(gui.tk, 'Tk', DummyTk)
+    monkeypatch.setattr(gui.tk, 'Frame', DummyFrame)
+    monkeypatch.setattr(gui.tk, 'Button', DummyButton)
+    monkeypatch.setattr(gui.tk, 'Label', DummyLabel)
+    monkeypatch.setattr(gui.tk, 'Entry', DummyEntry)
+    monkeypatch.setattr(gui.ttk, 'Progressbar', DummyPB)
+
+    root = gui.make_gui()
+    assert isinstance(root, DummyTk)
+    assert created['title'] == 'Olympia Restaurants'
+    assert created['widgets'] == [
+        'ZIP codes (comma separated)',
+        'entry',
+        'Refresh Restaurants',
+        'Fetch Toast Leads',
+        'Collected: 0',
+        'progress',
+    ]
+
+
+def test_run_refresh(monkeypatch):
+    called = {}
+
+    def fake_main(argv=None):
+        called['refresh'] = argv
+        gui.refresh_restaurants.smb_restaurants_data[:] = [1, 2, 3]
+
+    monkeypatch.setattr(gui.refresh_restaurants, 'main', fake_main)
+    monkeypatch.setattr(gui.messagebox, 'showinfo', lambda *a, **kw: called.setdefault('info', True))
+
+    class DummyEntry:
+        def get(self):
+            return '98765'
+
+    class DummyLabel:
+        def config(self, **kw):
+            called['label'] = kw
+
+    class DummyPB:
+        def start(self):
+            called['start'] = True
+        def stop(self):
+            called['stop'] = True
+
+    monkeypatch.setattr(gui, 'zip_entry', DummyEntry())
+    monkeypatch.setattr(gui, 'progress_label', DummyLabel())
+    monkeypatch.setattr(gui, 'progress_bar', DummyPB())
+
+    gui.run_refresh()
+
+    assert called['refresh'] == ['--zips', '98765']
+    assert called['info'] is True
+    assert called['label']['text'] == 'Collected: 3'
+    assert called['start'] and called['stop']
+
+
+def test_run_toast(monkeypatch):
+    called = {}
+    monkeypatch.setattr(gui.toast_leads, 'main', lambda: called.setdefault('toast', True))
+    monkeypatch.setattr(gui.messagebox, 'showinfo', lambda *a, **kw: called.setdefault('info', True))
+    gui.run_toast()
+    assert called == {'toast': True, 'info': True}
+


### PR DESCRIPTION
## Summary
- expand Tkinter GUI with ZIP code entry, progress bar and improved error reporting
- document GUI enhancements in README
- update tests for new widgets and behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fa46e90c4832d84a1e370f9a08072