### PR TITLE
Fix import exception handling

### DIFF
--- a/restaurants/loader.py
+++ b/restaurants/loader.py
@@ -15,8 +15,8 @@ from datetime import datetime, timezone
 
 try:
     from restaurants.utils import setup_logging
-except Exception:  # pragma: no cover - fallback for running as script
-    from utils import setup_logging
+except ImportError:  # pragma: no cover - fallback for running as script
+    from utils import setup_logging  # type: ignore
 
 DB_PATH = pathlib.Path(__file__).with_name("dela.sqlite")
 

--- a/restaurants/prep_restaurants.py
+++ b/restaurants/prep_restaurants.py
@@ -13,8 +13,8 @@ try:
         haversine_miles_series,
         setup_logging,
     )
-except Exception:  # pragma: no cover - fallback for running as script
-    from utils import haversine_miles, haversine_miles_series, setup_logging
+except ImportError:  # pragma: no cover - fallback for running as script
+    from utils import haversine_miles, haversine_miles_series, setup_logging  # type: ignore
 
 
 BX_LAT, BX_LON = 47.6154255, -122.2035954  # Bellevue Square Mall

--- a/restaurants/refresh_restaurants.py
+++ b/restaurants/refresh_restaurants.py
@@ -20,17 +20,17 @@ try:
     )
     from restaurants.chain_blocklist import CHAIN_BLOCKLIST
     from restaurants.network_utils import check_network
-except Exception:  # pragma: no cover - fallback for running as script
-    from utils import setup_logging, normalize_hours, haversine_miles
-    import loader
-    from config import (
+except ImportError:  # pragma: no cover - fallback for running as script
+    from utils import setup_logging, normalize_hours, haversine_miles  # type: ignore
+    import loader  # type: ignore
+    from config import (  # type: ignore
         GOOGLE_API_KEY,
         TARGET_OLYMPIA_ZIPS,
         OLYMPIA_LAT,
         OLYMPIA_LON,
     )
-    from chain_blocklist import CHAIN_BLOCKLIST  # list of substrings that ID big chains
-    from network_utils import check_network
+    from chain_blocklist import CHAIN_BLOCKLIST  # type: ignore  # list of substrings that ID big chains
+    from network_utils import check_network  # type: ignore
 MAX_PAGES = 15   # safety cap; tweak per need
 
 # -----------------------------------------------------------------------------

--- a/restaurants/toast_leads.py
+++ b/restaurants/toast_leads.py
@@ -15,18 +15,18 @@ try:
     from restaurants.chain_blocklist import CHAIN_BLOCKLIST            # names to skip
     from restaurants.network_utils import check_network                # simple ping check
     from restaurants.utils import setup_logging
-except Exception:  # pragma: no cover - fallback when running as script
-    from config import GOOGLE_API_KEY
+except ImportError:  # pragma: no cover - fallback when running as script
+    from config import GOOGLE_API_KEY  # type: ignore
     try:
-        from chain_blocklist import CHAIN_BLOCKLIST
-    except Exception:
+        from chain_blocklist import CHAIN_BLOCKLIST  # type: ignore
+    except ImportError:
         CHAIN_BLOCKLIST = []
     try:
-        from network_utils import check_network
-    except Exception:
-        def check_network() -> bool:
+        from network_utils import check_network  # type: ignore
+    except ImportError:
+        def check_network() -> bool:  # type: ignore[misc]
             return True
-    from utils import setup_logging
+    from utils import setup_logging  # type: ignore
 
 SEARCH_URL  = "https://maps.googleapis.com/maps/api/place/textsearch/json"
 DETAILS_URL = "https://maps.googleapis.com/maps/api/place/details/json"


### PR DESCRIPTION
## Summary
- narrow import fallback exceptions to ImportError
- silence mypy missing-module warnings for fallback imports

## Testing
- `mypy restaurants`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68406ce37638832d8b7ec16ddf34b718