### PR TITLE
Update load_seen_ids to handle specific errors

### DIFF
--- a/restaurants/toast_leads.py
+++ b/restaurants/toast_leads.py
@@ -38,7 +38,7 @@ def load_seen_ids(path: str = "seen_place_ids.json") -> set[str]:
     try:
         with open(path, "r", encoding="utf-8") as f:
             return set(json.load(f))
-    except Exception:
+    except (OSError, json.JSONDecodeError):
         return set()
 
 def save_seen_ids(ids: set[str], path: str = "seen_place_ids.json") -> None:


### PR DESCRIPTION
## Summary
- only catch `OSError` and `json.JSONDecodeError` in `load_seen_ids`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406df40760832dbaf220ada7d8f759