### PR TITLE
Exclude tests from distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="olympia-restaurants",
     version="0.1.0",
     description="Aggregator for Olympia, WA restaurant data",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests", "tests.*"]),
     python_requires=">=3.9",
     install_requires=[
         "requests",


### PR DESCRIPTION
## Summary
- avoid shipping tests in distribution by excluding them in `setup.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406fa7fa8c832db6f61e83d0decfe6