### PR TITLE
Add ZIP code validation

### DIFF
--- a/restaurants/toast_leads.py
+++ b/restaurants/toast_leads.py
@@ -14,7 +14,7 @@ try:
     from restaurants.config import GOOGLE_API_KEY
     from restaurants.chain_blocklist import CHAIN_BLOCKLIST            # names to skip
     from restaurants.network_utils import check_network                # simple ping check
-    from restaurants.utils import setup_logging
+    from restaurants.utils import setup_logging, is_valid_zip
 except ImportError:  # pragma: no cover - fallback when running as script
     from config import GOOGLE_API_KEY  # type: ignore
     try:
@@ -26,7 +26,7 @@ except ImportError:  # pragma: no cover - fallback when running as script
     except ImportError:
         def check_network() -> bool:  # type: ignore[misc]
             return True
-    from utils import setup_logging  # type: ignore
+    from utils import setup_logging, is_valid_zip  # type: ignore
 
 SEARCH_URL  = "https://maps.googleapis.com/maps/api/place/textsearch/json"
 DETAILS_URL = "https://maps.googleapis.com/maps/api/place/details/json"
@@ -73,7 +73,16 @@ ZIP_FILE = "toast_zips.txt"
 def load_zip_codes(path: str = ZIP_FILE) -> list[str]:
     try:
         with open(path, "r", encoding="utf-8") as f:
-            return [line.strip() for line in f if line.strip()]
+            codes: list[str] = []
+            for line in f:
+                code = line.strip()
+                if not code:
+                    continue
+                if is_valid_zip(code):
+                    codes.append(code)
+                else:
+                    logging.warning("Invalid ZIP code ignored: %s", code)
+            return codes
     except FileNotFoundError:
         return []
 

--- a/restaurants/utils.py
+++ b/restaurants/utils.py
@@ -8,6 +8,15 @@ import pandas as pd
 
 THIN_SPACE_CHARS = '\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a'
 
+# Basic US ZIP or ZIP+4 format
+ZIP_RE = re.compile(r"^\d{5}(?:-\d{4})?$")
+
+
+def is_valid_zip(zip_code: str) -> bool:
+    """Return True if ``zip_code`` is a valid 5-digit or ZIP+4 code."""
+
+    return bool(ZIP_RE.fullmatch(zip_code.strip()))
+
 
 def haversine_miles(lat1: float, lon1: float, lat2: float, lon2: float):
     """Great‑circle distance in miles between two lat/lon points.

--- a/tests/test_toast_leads.py
+++ b/tests/test_toast_leads.py
@@ -35,3 +35,9 @@ def test_fetch_details_error(monkeypatch):
 
     assert tl.fetch_details("pid", DummySession()) == {}
 
+
+def test_load_zip_codes_validation(tmp_path):
+    path = tmp_path / "zips.txt"
+    path.write_text("98101\nabcde\n12345-6789\n")
+    assert tl.load_zip_codes(path) == ["98101", "12345-6789"]
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 import math
-from restaurants.utils import normalize_hours, haversine_miles
+from restaurants.utils import normalize_hours, haversine_miles, is_valid_zip
 
 
 def test_normalize_hours_basic():
@@ -39,3 +39,10 @@ def test_haversine_invalid_nan():
     nan = math.nan
     assert haversine_miles(nan, -122.0, 47.0, -123.0) is None
     assert haversine_miles(47.0, nan, 47.0, -123.0) is None
+
+
+def test_is_valid_zip():
+    assert is_valid_zip("98101")
+    assert is_valid_zip("12345-6789")
+    assert not is_valid_zip("1234")
+    assert not is_valid_zip("abcd")


### PR DESCRIPTION
## Summary
- validate ZIP codes in toast leads loader
- add `is_valid_zip` helper for ZIP validation
- warn on invalid ZIP codes
- test load_zip_codes filtering
- test new `is_valid_zip` utility

## Testing
- `pytest -q`
- `mypy restaurants` *(fails: missing type stubs)*

------
https://chatgpt.com/codex/tasks/task_e_68406bb30b54832d9f1670633a306de5