### PR TITLE
Add Yelp match threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ data and fetching Toast leads.
 Run `google_yelp_enrich.py` to supplement Google Places rows with Yelp ratings and
 categories. The script searches Yelp by the restaurant name and city and scans
 up to five candidates. `rapidfuzz.fuzz.token_set_ratio` picks the best match and
- only applies it when the score is at least 60. If no strong match is found and a
+ only applies it when the score meets the `YELP_MATCH_THRESHOLD` (60 by default). If no strong match is found and a
 phone number is available, the script falls back to a phone-based Yelp search.
 Rows without a valid match are left unchanged and marked as `FAIL`.
 

--- a/restaurants/google_yelp_enrich.py
+++ b/restaurants/google_yelp_enrich.py
@@ -23,6 +23,9 @@ YELP_SEARCH_URL = "https://api.yelp.com/v3/businesses/search"
 YELP_DETAILS_URL = "https://api.yelp.com/v3/businesses/{id}"
 YELP_REVIEWS_URL = "https://api.yelp.com/v3/businesses/{id}/reviews"
 
+# Minimum fuzzy match score required to accept a Yelp business match
+YELP_MATCH_THRESHOLD = 60
+
 
 def search_google_place(name: str, location: str, session: requests.Session) -> dict[str, Any]:
     """Return the first Google place result for ``name`` and ``location``."""
@@ -42,6 +45,8 @@ def _pick_best_by_name(name: str, businesses: Iterable[dict[str, Any]]) -> dict[
         if score > best_score:
             best = biz
             best_score = score
+    if best_score < YELP_MATCH_THRESHOLD:
+        return {}
     return best or {}
 
 

--- a/tests/test_google_yelp_enrich.py
+++ b/tests/test_google_yelp_enrich.py
@@ -23,7 +23,7 @@ def test_enrich_restaurant_success(monkeypatch):
         if url == gye.GOOGLE_SEARCH_URL:
             return DummyResp({"results": [{"name": "Foo", "place_id": "p1", "geometry": {"location": {"lat": 1.0, "lng": 2.0}}}]})
         elif url == gye.YELP_SEARCH_URL:
-            return DummyResp({"businesses": [{"id": "y1"}]})
+            return DummyResp({"businesses": [{"id": "y1", "name": "Foo"}]})
         elif url == gye.YELP_DETAILS_URL.format(id="y1"):
             return DummyResp({"id": "y1", "name": "Foo Yelp"})
         elif url == gye.YELP_REVIEWS_URL.format(id="y1"):


### PR DESCRIPTION
## Summary
- add a new `YELP_MATCH_THRESHOLD` constant to `google_yelp_enrich.py`
- use threshold in `_pick_best_by_name`
- tweak README to mention the new constant
- update test data for Yelp enrichment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a211ab28c832db656acefa95ed738