### PR TITLE
Fix load_dotenv fallback type

### DIFF
--- a/restaurants/config.py
+++ b/restaurants/config.py
@@ -18,9 +18,9 @@ logger = logging.getLogger(__name__)
 try:
     from dotenv import load_dotenv
 except ImportError:
-    def load_dotenv(*_a: Any, **_kw: Any) -> None:
+    def load_dotenv(*_a: Any, **_kw: Any) -> bool:
         logger.warning("python-dotenv not installed, .env file not loaded")
-        return None
+        return False
 
 load_dotenv()
 


### PR DESCRIPTION
## Summary
- return `False` from fallback `load_dotenv`

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a21fda90c832d9045100440f0333f