### PR TITLE
Fix spacing and long lines

### DIFF
--- a/restaurants/loader.py
+++ b/restaurants/loader.py
@@ -80,6 +80,8 @@ RENAMES = {
 # --------------------------------------------------------------------------- #
 # Helpers
 # --------------------------------------------------------------------------- #
+
+
 def ensure_db() -> sqlite3.Connection:
     """Create dela.sqlite and the places table if they don’t exist yet."""
     conn = sqlite3.connect(DB_PATH)
@@ -199,7 +201,10 @@ def load_yelp_json(json_file: pathlib.Path) -> None:
         cur.execute(insert_sql, [row.get(c) for c in cols])
 
     conn.commit()
-    logging.info("Yelp JSON loaded. Rows now in table: %s", cur.execute("SELECT COUNT(*) FROM places").fetchone()[0])
+    logging.info(
+        "Yelp JSON loaded. Rows now in table: %s",
+        cur.execute("SELECT COUNT(*) FROM places").fetchone()[0],
+    )
     conn.close()
 
 
@@ -207,8 +212,12 @@ def load_yelp_json(json_file: pathlib.Path) -> None:
 # CLI
 # --------------------------------------------------------------------------- #
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Load a Google-Places CSV into dela.sqlite")
-    parser.add_argument("csv", help="Path to CSV produced by refresh_restaurants.py")
+    parser = argparse.ArgumentParser(
+        description="Load a Google-Places CSV into dela.sqlite"
+    )
+    parser.add_argument(
+        "csv", help="Path to CSV produced by refresh_restaurants.py"
+    )
     args = parser.parse_args()
 
     csv_path = pathlib.Path(args.csv).expanduser()

--- a/restaurants/network_utils.py
+++ b/restaurants/network_utils.py
@@ -10,11 +10,11 @@ def check_network(
 ) -> bool:
     """Return True if network is reachable.
 
-    A lightweight ``GET`` request is used by default as some networks block ``HEAD``
-    requests. You can override ``method`` to ``"HEAD"`` if desired or specify a
-    custom URL.
+    A lightweight ``GET`` request is used by default since some
+    networks block ``HEAD`` requests. Override ``method`` to
+    ``"HEAD"`` if desired or specify a custom URL.
 
-    The URL, method, and timeout may also be overridden using the environment
+    The URL, method, and timeout may also be overridden with environment
     variables ``NETWORK_TEST_URL``, ``NETWORK_TEST_METHOD`` and
     ``NETWORK_TEST_TIMEOUT``. This makes the connectivity check configurable on
     restricted networks.
@@ -26,7 +26,9 @@ def check_network(
         try:
             timeout = int(timeout_env)
         except ValueError:
-            logging.error("Invalid NETWORK_TEST_TIMEOUT value: %s", timeout_env)
+            logging.error(
+                "Invalid NETWORK_TEST_TIMEOUT value: %s", timeout_env
+            )
 
     try:
         if method.upper() == "HEAD":
@@ -42,4 +44,3 @@ def check_network(
         return False
     except requests.RequestException:
         return False
-


### PR DESCRIPTION
## Summary
- insert PEP8 blank lines before `ensure_db`
- split long log and argparse lines in loader
- wrap docstring text and error logging in network utils
- drop trailing blank line

## Testing
- `flake8 restaurants/loader.py`
- `flake8 restaurants/network_utils.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a229eddd8832d88ff51e9825c8fb7