### PR TITLE
Fix Yelp param types

### DIFF
--- a/restaurants/google_yelp_enrich.py
+++ b/restaurants/google_yelp_enrich.py
@@ -59,9 +59,9 @@ def search_yelp_business(
     headers: dict[str, str],
 ) -> dict[str, Any]:
     """Return the best Yelp business for ``name`` using coords or location."""
-    params = {"term": name, "limit": 5}
+    params: dict[str, str | int | float | None] = {"term": name, "limit": 5}
     if lat is not None and lon is not None:
-        params.update({"latitude": lat, "longitude": lon})
+        params.update({"latitude": str(lat), "longitude": str(lon)})
     else:
         params["location"] = location
 


### PR DESCRIPTION
## Summary
- update type annotation for `params` in `search_yelp_business`
- convert latitude and longitude to strings

## Testing
- `mypy restaurants`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a2522b3c0832d9197c57a3e4c13fc