### PR TITLE
Add .env file with API keys

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,18 @@
+# Copy this file to `.env` and fill in your API keys.
+#
+# YELP_API_KEY is kept for optional Yelp integrations that may exist outside
+# of this repository.
+YELP_API_KEY=G6YJ1moj0ZpmVD_L1FU85CqtDGapaRnHCVKgRDEJ4PFHrzXeLxgRcKAzSGewwNLgsf5a-c0E3ciwQG_dpYY021ZrfPiWnDnIpWJWWA-bvn-IZiNfbFCWQT_HXKk6aHYx
+
+# Google Places API key used by `refresh_restaurants.py` when querying
+# restaurants from Google.
+GOOGLE_API_KEY=AIzaSyAUP70I-z0V4AAZa8FNwqNGWvsbx9YTRUA
+
+# DoorDash API key for scraping DoorDash listings in
+# `refresh_restaurants.py`.
+DOORDASH_API_KEY=
+
+# Uber Eats API key for scraping Uber Eats listings in
+# `refresh_restaurants.py`.
+UBER_EATS_API_KEY=
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 __pycache__/
 *.pyc
-.env
 *.sqlite
 error.log
 # Ignore generated CSV outputs


### PR DESCRIPTION
## Summary
- create `.env` populated with API keys so scripts can read them
- allow `.env` to be tracked by removing it from `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a3853fd1c832da7128c268be3fe0e