### PR TITLE
Improve test setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,14 +80,20 @@ comma‑separated string, with the first alias stored separately as
 
 ## Tests
 
-Ensure the `restaurants` package is importable before running the tests. The
-simplest approach is to install the project in editable mode:
+Ensure the `restaurants` package is importable before running the tests.
+All runtime dependencies live in `requirements.txt` while the testing tools
+are listed in `requirements-dev.txt`:
 
 ```bash
 pip install -e .
 pip install -r requirements-dev.txt
 pytest
 ```
+
+The dev file includes `pytest`, `mypy` and type stubs. It also pulls in the
+packages from `requirements.txt` so a single install command prepares the
+environment. For convenience you can run `./setup_tests.sh` to perform these
+steps automatically.
 
 Alternatively you can adjust `PYTHONPATH` so the `restaurants` imports in the
 tests resolve.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 pytest
 mypy
 types-requests

--- a/setup_tests.sh
+++ b/setup_tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+# Install runtime and development dependencies for running tests
+pip install -e .
+pip install -r requirements-dev.txt


### PR DESCRIPTION
## Summary
- document dependency installation steps in the README
- include runtime requirements from `requirements.txt` in `requirements-dev.txt`
- add `setup_tests.sh` helper script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a3ecb08d0832d809d503041488ffa