### PR TITLE
Update default ZIP to 98501 only

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ This project collects restaurant information for ZIP codes around Olympia, Washi
    ```
 
 By default `refresh_restaurants.py` iterates over the `TARGET_OLYMPIA_ZIPS`
-list in `config.py`.  You can pass `--zips 98501,98502` or enter a list when
-prompted to restrict the fetch to specific ZIP codes.
+list in `config.py`, which now contains just `98501`. You can pass `--zips`
+with any additional ZIP codes (e.g. `--zips 98502`) or enter a comma-separated
+list when prompted to query other areas.
 
 ## Optional GUI
 

--- a/restaurants/config.py
+++ b/restaurants/config.py
@@ -56,7 +56,7 @@ if _missing:
 
 # List of ZIP codes for the Olympia, WA area
 TARGET_OLYMPIA_ZIPS: List[str] = [
-    "98501", "98502"
+    "98501"
 ]
 
 # Geographic coordinates for Olympia, WA


### PR DESCRIPTION
## Summary
- default to only ZIP code 98501 in `config.py`
- document new default in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a41fe4d08832daeb4469c2de748a5