### PR TITLE
Fix GUI script import issue

### DIFF
--- a/restaurants/gui.py
+++ b/restaurants/gui.py
@@ -9,7 +9,11 @@ from __future__ import annotations
 import tkinter as tk
 from tkinter import messagebox
 
-from . import refresh_restaurants, toast_leads
+try:
+    from . import refresh_restaurants, toast_leads
+except ImportError:  # pragma: no cover - fallback for running as script
+    import refresh_restaurants  # type: ignore
+    import toast_leads  # type: ignore
 
 
 def run_refresh() -> None:


### PR DESCRIPTION
## Summary
- allow running `gui.py` directly by falling back to absolute imports

## Testing
- `pytest -q`
- `python restaurants/gui.py --help` *(fails: no display available)*

------
https://chatgpt.com/codex/tasks/task_e_684a4928b264832d9fea3878b7eade83