### PR TITLE
Add concurrent start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,16 @@ The map fetches `/static/restaurants.geojson` from the backend and displays the
 locations using Mapbox GL JS. Set `mapboxgl.accessToken` in `src/App.jsx` to your
 Mapbox token before running.
 
+You can also run both the backend refresh command and the React dev server at
+once using the root `package.json`:
+
+```bash
+npm start
+```
+
+This command launches `python -m restaurants.refresh_restaurants` and `npm
+--prefix frontend run dev` concurrently.
+
 ## Makefile
 
 A Makefile streamlines the workflow of fetching data and launching the frontend. Run:

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "restaurants-root",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "start": "concurrently \"python -m restaurants.refresh_restaurants\" \"npm --prefix frontend run dev\""
+  },
+  "devDependencies": {
+    "concurrently": "^9.1.2"
+  }
+}


### PR DESCRIPTION
## Summary
- create a root `package.json` with a start script that runs the Python refresh and React dev server concurrently
- document the new workflow in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a6f6f50fc832d9835bf6ca88d2232