### PR TITLE
Add Mapbox token config

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -16,3 +16,6 @@ DOORDASH_API_KEY=
 # `refresh_restaurants.py`.
 UBER_EATS_API_KEY=
 
+# Mapbox access token for the frontend map.
+MAPBOX_TOKEN=
+

--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ This project collects restaurant information for ZIP codes around Olympia, Washi
    ```bash
    pip install -e .
    ```
-2. Copy `.env.template` to `.env` and add your `GOOGLE_API_KEY`. Other keys
-   like `YELP_API_KEY` are optional but required for Yelp utilities. The `.env`
-   file is listed in `.gitignore` and should remain untracked. Configuration is
-   loaded via `config.py` which also exposes `DEFAULT_ZIP` (set to `98501`).
+2. Copy `.env.template` to `.env` and add your `GOOGLE_API_KEY` and
+   `MAPBOX_TOKEN`. Other keys like `YELP_API_KEY` are optional but required for
+   Yelp utilities. The `.env` file is listed in `.gitignore` and should remain
+   untracked. Configuration is loaded via `config.py` which also exposes
+   `DEFAULT_ZIP` (set to `98501`).
 3. Run the refresh command:
    ```bash
    refresh-restaurants
@@ -132,8 +133,15 @@ npm run dev
 ```
 
 The map fetches `/static/restaurants.geojson` from the backend and displays the
-locations using Mapbox GL JS. Set `mapboxgl.accessToken` in `src/App.jsx` to your
-Mapbox token before running.
+locations using Mapbox GL JS. Create `frontend/.env.local` with your Mapbox
+token:
+
+```bash
+VITE_MAPBOX_TOKEN=<your token>
+```
+
+`src/App.jsx` reads this value via `import.meta.env.VITE_MAPBOX_TOKEN` when the
+dev server runs.
 
 You can also run both the backend refresh command and the React dev server at
 once using the root `package.json`:

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,7 +3,7 @@ import mapboxgl from 'mapbox-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import './App.css';
 
-mapboxgl.accessToken = 'YOUR_MAPBOX_ACCESS_TOKEN';
+mapboxgl.accessToken = import.meta.env.VITE_MAPBOX_TOKEN;
 
 function App() {
   const mapContainer = useRef(null);


### PR DESCRIPTION
## Summary
- add `MAPBOX_TOKEN` to `.env.template`
- document `.env` and `frontend/.env.local` setup
- read Vite env variable in `App.jsx`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a7021af8c832dabdcbd09167aa0b5