### PR TITLE
Add automated refresh workflow

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -1,0 +1,47 @@
+name: Daily refresh
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    env:
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      YELP_API_KEY: ${{ secrets.YELP_API_KEY }}
+      DOORDASH_API_KEY: ${{ secrets.DOORDASH_API_KEY }}
+      UBER_EATS_API_KEY: ${{ secrets.UBER_EATS_API_KEY }}
+      FRONTEND_DEPLOY_HOOK_URL: ${{ secrets.FRONTEND_DEPLOY_HOOK_URL }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          pip install -r requirements.txt
+          pip install -e .
+      - name: Refresh restaurants
+        run: python -m restaurants.refresh_restaurants
+      - name: Export GeoJSON
+        run: python -m restaurants.export_geojson
+      - name: Commit updated geojson
+        id: commit
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          if git diff --quiet backend/static/restaurants.geojson; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            git add backend/static/restaurants.geojson
+            git commit -m "Update restaurants.geojson"
+            git push
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Trigger frontend deployment
+        if: steps.commit.outputs.changed == 'true' && env.FRONTEND_DEPLOY_HOOK_URL != ''
+        run: |
+          curl -X POST "$FRONTEND_DEPLOY_HOOK_URL"


### PR DESCRIPTION
## Summary
- set up a daily refresh action that installs requirements, refreshes restaurant data, exports GeoJSON and commits the result
- optionally hit a deployment webhook when the GeoJSON file changes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a7037edd0832da9f13c8a484755a3