### PR TITLE
Improve failure handling for refresh script

### DIFF
--- a/tests/test_refresh_restaurants.py
+++ b/tests/test_refresh_restaurants.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 
 os.environ.setdefault("GOOGLE_API_KEY", "DUMMY")
 
@@ -88,4 +89,87 @@ def test_google_details_use_threadpool(monkeypatch):
     assert executors
     assert len(executors[0].submitted) == 2
     assert detail_calls == ["p1", "p2"]
+
+
+def test_fetch_google_places_no_network(monkeypatch):
+    monkeypatch.setattr(rr, "check_network", lambda: False)
+    with pytest.raises(SystemExit):
+        rr.fetch_google_places(["98501"])
+
+
+def test_fetch_google_places_textsearch_error(monkeypatch):
+    monkeypatch.setattr(rr, "check_network", lambda: True)
+
+    class DummySessionGet:
+        def __call__(self, url, params=None, timeout=None):
+            if "textsearch" in url:
+                raise rr.requests.RequestException("boom")
+            raise AssertionError("unexpected url " + url)
+
+    monkeypatch.setattr(rr.requests.sessions.Session, "get", DummySessionGet())
+
+    with pytest.raises(SystemExit):
+        rr.fetch_google_places(["98501"])
+
+
+def test_fetch_google_places_details_failure(monkeypatch):
+    monkeypatch.setattr(rr, "check_network", lambda: True)
+
+    class DummyResp:
+        def __init__(self, data):
+            self._data = data
+            self.status_code = 200
+        def raise_for_status(self):
+            pass
+        def json(self):
+            return self._data
+
+    def dummy_get(self, url, params=None, timeout=None):
+        if "textsearch" in url:
+            return DummyResp({
+                "results": [{
+                    "name": "A",
+                    "formatted_address": "addr1",
+                    "place_id": "p1",
+                    "rating": 4.0,
+                    "user_ratings_total": 1,
+                    "business_status": "OP",
+                    "geometry": {"location": {"lat": 1, "lng": 2}},
+                }]
+            })
+        elif "details" in url:
+            raise RuntimeError("boom")
+        raise AssertionError("unexpected url " + url)
+
+    monkeypatch.setattr(rr.requests.sessions.Session, "get", dummy_get)
+    monkeypatch.setattr(rr.time, "sleep", lambda _x: None)
+
+    class DummyFuture:
+        def __init__(self, res):
+            self._res = res
+        def result(self):
+            return self._res
+
+    class DummyExecutor:
+        def __init__(self, max_workers=None):
+            pass
+        def submit(self, fn, *a, **kw):
+            return DummyFuture(fn(*a, **kw))
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(rr, "ThreadPoolExecutor", DummyExecutor)
+    monkeypatch.setattr(rr, "as_completed", lambda it: it)
+
+    with pytest.raises(SystemExit):
+        rr.fetch_google_places(["98501"])
+
+
+def test_main_missing_api_key(monkeypatch):
+    monkeypatch.setattr(rr, "GOOGLE_API_KEY", None)
+    monkeypatch.setattr(rr, "fetch_google_places", lambda *_a, **_k: (_ for _ in ()).throw(AssertionError))
+    with pytest.raises(SystemExit):
+        rr.main(["--zips", "98501"])
 


### PR DESCRIPTION
## Summary
- exit if `GOOGLE_API_KEY` is missing when running `refresh_restaurants.main`
- abort `fetch_google_places` or `fetch_osm` when network is unavailable
- abort when Google API requests fail after retries
- add tests for new exit behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a70fb9d80832d9aea4e2bac79bce9