### PR TITLE
Fix setup instructions for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,11 @@ comma‑separated string, with the first alias stored separately as
 ## Tests
 
 Ensure the `restaurants` package is importable before running the tests.
-All runtime dependencies live in `requirements.txt` while the testing tools
-are listed in `requirements-dev.txt`:
+Running `pytest` without installing dependencies will fail with missing-module
+errors. Install the runtime and development requirements first or simply run
+`./setup_tests.sh` which performs these steps automatically. All runtime
+dependencies live in `requirements.txt` while the testing tools are listed in
+`requirements-dev.txt`:
 
 ```bash
 pip install -e .


### PR DESCRIPTION
## Summary
- document that tests fail until dependencies are installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a73607ef4832d93dd6d7b7a58529b