### PR TITLE
Fix setup instructions for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,11 @@ comma‑separated string, with the first alias stored separately as
 ## Tests
 
 Ensure the `restaurants` package is importable before running the tests.
-All runtime dependencies live in `requirements.txt` while the testing tools
-are listed in `requirements-dev.txt`:
+Running `pytest` without installing dependencies will fail with missing-module
+errors. Install the runtime and development requirements first or simply run
+`./setup_tests.sh` which performs these steps automatically. All runtime
+dependencies live in `requirements.txt` while the testing tools are listed in
+`requirements-dev.txt`:
 
 ```bash
 pip install -e .
@@ -95,8 +98,8 @@ pytest
 
 The dev file includes `pytest`, `mypy` and type stubs. It also pulls in the
 packages from `requirements.txt` so a single install command prepares the
-environment. For convenience you can run `./setup_tests.sh` to perform these
-steps automatically.
+environment. For convenience you can run `./setup_tests.sh` which installs the
+requirements and runs the test suite automatically.
 
 Alternatively you can adjust `PYTHONPATH` so the `restaurants` imports in the
 tests resolve.

--- a/setup_tests.sh
+++ b/setup_tests.sh
@@ -3,3 +3,4 @@ set -e
 # Install runtime and development dependencies for running tests
 pip install -e .
 pip install -r requirements-dev.txt
+pytest -q


### PR DESCRIPTION
## Summary
- document that tests fail until dependencies are installed
- automatically run the test suite inside `setup_tests.sh`

## Testing
- `pytest -q`
- `./setup_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684a73607ef4832d93dd6d7b7a58529b