### PR TITLE
Pin dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ This project collects restaurant information for ZIP codes around Olympia, Washi
 
 ## Setup
 
-1. Install the project in editable mode (the `requests` dependency is
-   required for network operations):
+1. Install the project in editable mode. The `requirements.txt` file pins
+   specific versions of each dependency for reproducible installs:
    ```bash
    pip install -e .
+   pip install -r requirements.txt
    ```
 2. Copy `.env.template` to `.env` and add your `GOOGLE_API_KEY` and
    `MAPBOX_TOKEN`. Other keys like `YELP_API_KEY` are optional but required for

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
-pytest
-mypy
-types-requests
-pandas-stubs
-tqdm
+pytest==8.4.0
+mypy==1.16.0
+types-requests==2.32.4.20250611
+pandas-stubs==2.2.3.250527
+tqdm==4.67.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-requests
-python-dotenv
-pandas
-overpy
-geocoder
-rapidfuzz
+requests==2.32.4
+python-dotenv==1.1.0
+pandas==2.3.0
+overpy==0.7
+geocoder==1.38.1
+rapidfuzz==3.13.0
 # optional: used for GeoJSON export
-shapely
+shapely==2.1.1
 
-pyyaml
-XlsxWriter
-tqdm
+pyyaml==6.0.2
+XlsxWriter==3.2.3
+tqdm==4.67.1


### PR DESCRIPTION
## Summary
- pin version numbers in runtime and dev requirements
- mention pinned requirements in README setup instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a848ff774832db9fc9f9e47d57824