### PR TITLE
Set auth header on Yelp session

### DIFF
--- a/restaurants/google_yelp_enrich.py
+++ b/restaurants/google_yelp_enrich.py
@@ -56,7 +56,6 @@ def search_yelp_business(
     lon: float | None,
     location: str,
     session: requests.Session,
-    headers: dict[str, str],
 ) -> dict[str, Any]:
     """Return the best Yelp business for ``name`` using coords or location."""
     params: dict[str, str | int | float | None] = {"term": name, "limit": 5}
@@ -65,7 +64,7 @@ def search_yelp_business(
     else:
         params["location"] = location
 
-    resp = session.get(YELP_SEARCH_URL, headers=headers, params=params, timeout=10)
+    resp = session.get(YELP_SEARCH_URL, params=params, timeout=10)
     resp.raise_for_status()
     results = resp.json().get("businesses") or []
 
@@ -73,7 +72,7 @@ def search_yelp_business(
         params.pop("latitude", None)
         params.pop("longitude", None)
         params["location"] = location
-        resp = session.get(YELP_SEARCH_URL, headers=headers, params=params, timeout=10)
+        resp = session.get(YELP_SEARCH_URL, params=params, timeout=10)
         resp.raise_for_status()
         results = resp.json().get("businesses") or []
 
@@ -81,20 +80,20 @@ def search_yelp_business(
 
 
 def get_yelp_details(
-    business_id: str, session: requests.Session, headers: dict[str, str]
+    business_id: str, session: requests.Session
 ) -> dict[str, Any]:
     resp = session.get(
-        YELP_DETAILS_URL.format(id=business_id), headers=headers, timeout=10
+        YELP_DETAILS_URL.format(id=business_id), timeout=10
     )
     resp.raise_for_status()
     return resp.json()
 
 
 def get_yelp_reviews(
-    business_id: str, session: requests.Session, headers: dict[str, str]
+    business_id: str, session: requests.Session
 ) -> dict[str, Any]:
     resp = session.get(
-        YELP_REVIEWS_URL.format(id=business_id), headers=headers, timeout=10
+        YELP_REVIEWS_URL.format(id=business_id), timeout=10
     )
     resp.raise_for_status()
     return resp.json()
@@ -111,6 +110,7 @@ def enrich_restaurant(name: str, location: str) -> dict[str, Any]:
     headers = {"Authorization": f"Bearer {YELP_API_KEY}"}
 
     with requests.Session() as session:
+        session.headers.update(headers)
         g_place = search_google_place(name, location, session)
         if not g_place:
             return {}
@@ -121,12 +121,12 @@ def enrich_restaurant(name: str, location: str) -> dict[str, Any]:
         yelp_reviews: Dict[str, Any] = {}
 
         yelp_biz = search_yelp_business(
-            g_place.get("name", name), lat, lon, location, session, headers
+            g_place.get("name", name), lat, lon, location, session
         )
         biz_id = yelp_biz.get("id")
         if biz_id:
-            yelp_details = get_yelp_details(biz_id, session, headers)
-            yelp_reviews = get_yelp_reviews(biz_id, session, headers)
+            yelp_details = get_yelp_details(biz_id, session)
+            yelp_reviews = get_yelp_reviews(biz_id, session)
 
         cuisines = [c.get("alias") for c in (yelp_details.get("categories") or []) if c.get("alias")]
         summary = {


### PR DESCRIPTION
## Summary
- set Authorization header via `session.headers.update`
- remove redundant `headers` arguments from Yelp requests

## Testing
- `./setup_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684a868156e8832d9fdf7018bf589a31