### PR TITLE
Disable frontend for now

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -41,7 +41,3 @@ jobs:
             git push
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
-      - name: Trigger frontend deployment
-        if: steps.commit.outputs.changed == 'true' && env.FRONTEND_DEPLOY_HOOK_URL != ''
-        run: |
-          curl -X POST "$FRONTEND_DEPLOY_HOOK_URL"

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,10 @@
-.PHONY: all refresh export serve
+.PHONY: all refresh export
 
 all:
-	$(MAKE) refresh export serve
+        $(MAKE) refresh export
 
 refresh:
 	python -m restaurants.refresh_restaurants
 
 export:
-	python -m restaurants.export_geojson
-
-serve:
-	cd frontend && npm run dev
+        python -m restaurants.export_geojson

--- a/README.md
+++ b/README.md
@@ -126,10 +126,11 @@ Run the helper script after cleaning the data to create `restaurants.geojson` in
 python -m restaurants.export_geojson
 ```
 
-## React development server
+## React development server (disabled)
 
-The React frontend lives in `frontend/`. Install dependencies and start the dev
-server with:
+The React frontend lives in `frontend/`, but it is currently disabled. If you
+want to work on the UI later install dependencies and start the dev server
+manually with:
 
 ```bash
 cd frontend
@@ -148,22 +149,15 @@ VITE_MAPBOX_TOKEN=<your token>
 `src/App.jsx` reads this value via `import.meta.env.VITE_MAPBOX_TOKEN` when the
 dev server runs.
 
-You can also run both the backend refresh command and the React dev server at
-once using the root `package.json`:
-
-```bash
-npm start
-```
-
-This command launches `python -m restaurants.refresh_restaurants` and `npm
---prefix frontend run dev` concurrently.
+Running `npm start` now only refreshes restaurant data because the frontend is
+disabled.
 
 ## Makefile
 
-A Makefile streamlines the workflow of fetching data and launching the frontend. Run:
+The `Makefile` streamlines the workflow of refreshing data and exporting GeoJSON. Run:
 
 ```bash
 make all
 ```
 
-The command refreshes restaurant data, exports `restaurants.geojson`, and starts the React development server.
+This command refreshes restaurant data and exports `restaurants.geojson`.

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "start": "concurrently \"python -m restaurants.refresh_restaurants\" \"npm --prefix frontend run dev\""
+    "start": "python -m restaurants.refresh_restaurants"
   },
-  "devDependencies": {
-    "concurrently": "^9.1.2"
-  }
+  "devDependencies": {}
 }


### PR DESCRIPTION
## Summary
- disable the frontend start script
- remove dev server from Makefile
- stop triggering a frontend deploy in workflow
- document that the React frontend is disabled

## Testing
- `./setup_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684af3123e58832dad3a6032bc955b91