### PR TITLE
Improve Yelp enrichment

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ data and fetching Toast leads.
 Run `google_yelp_enrich.py` to supplement Google Places rows with Yelp ratings and
 categories. The script searches Yelp by the restaurant name and city and scans
 up to five candidates. `rapidfuzz.fuzz.token_set_ratio` picks the best match and
- only applies it when the score meets the `YELP_MATCH_THRESHOLD` (60 by default). If no strong match is found and a
-phone number is available, the script falls back to a phone-based Yelp search.
-Rows without a valid match are left unchanged and marked as `FAIL`.
+only applies it when the score meets the `YELP_MATCH_THRESHOLD` (60 by default).
+When that fails the utility fetches the place's phone number from Google and
+performs a Yelp phone search. Rows without a valid match are left unchanged and
+marked as `FAIL`. The summary section now includes rating, price tier, phone and
+closed status in addition to the list of cuisines.
 
 Ensure the `dela.sqlite` database exists (created by `refresh_restaurants.py`)
 and that `YELP_API_KEY` is set before running. If either is missing the script

--- a/restaurants/google_yelp_enrich.py
+++ b/restaurants/google_yelp_enrich.py
@@ -19,9 +19,11 @@ from .config import GOOGLE_API_KEY, YELP_API_KEY
 from .network_utils import check_network
 
 GOOGLE_SEARCH_URL = "https://maps.googleapis.com/maps/api/place/textsearch/json"
+GOOGLE_DETAILS_URL = "https://maps.googleapis.com/maps/api/place/details/json"
 YELP_SEARCH_URL = "https://api.yelp.com/v3/businesses/search"
 YELP_DETAILS_URL = "https://api.yelp.com/v3/businesses/{id}"
 YELP_REVIEWS_URL = "https://api.yelp.com/v3/businesses/{id}/reviews"
+YELP_PHONE_SEARCH_URL = "https://api.yelp.com/v3/businesses/search/phone"
 
 # Minimum fuzzy match score required to accept a Yelp business match
 YELP_MATCH_THRESHOLD = 60
@@ -34,6 +36,18 @@ def search_google_place(name: str, location: str, session: requests.Session) -> 
     resp.raise_for_status()
     results = resp.json().get("results") or []
     return results[0] if results else {}
+
+
+def get_google_details(place_id: str, session: requests.Session) -> dict[str, Any]:
+    """Return phone details for a Google place."""
+    params = {
+        "place_id": place_id,
+        "key": GOOGLE_API_KEY,
+        "fields": "formatted_phone_number,international_phone_number",
+    }
+    resp = session.get(GOOGLE_DETAILS_URL, params=params, timeout=10)
+    resp.raise_for_status()
+    return resp.json().get("result", {})
 
 
 def _pick_best_by_name(name: str, businesses: Iterable[dict[str, Any]]) -> dict[str, Any]:
@@ -79,6 +93,17 @@ def search_yelp_business(
     return _pick_best_by_name(name, results)
 
 
+def search_yelp_by_phone(phone: str, session: requests.Session) -> dict[str, Any]:
+    """Return the first Yelp business for the given phone number."""
+    if not phone:
+        return {}
+    digits = "".join(c for c in phone if c.isdigit() or c == "+")
+    resp = session.get(YELP_PHONE_SEARCH_URL, params={"phone": digits}, timeout=10)
+    resp.raise_for_status()
+    results = resp.json().get("businesses") or []
+    return results[0] if results else {}
+
+
 def get_yelp_details(
     business_id: str, session: requests.Session
 ) -> dict[str, Any]:
@@ -114,6 +139,7 @@ def enrich_restaurant(name: str, location: str) -> dict[str, Any]:
         g_place = search_google_place(name, location, session)
         if not g_place:
             return {}
+        g_details = get_google_details(g_place.get("place_id", ""), session)
         loc = g_place.get("geometry", {}).get("location", {})
         lat, lon = loc.get("lat"), loc.get("lng")
         yelp_biz: Dict[str, Any] = {}
@@ -123,6 +149,9 @@ def enrich_restaurant(name: str, location: str) -> dict[str, Any]:
         yelp_biz = search_yelp_business(
             g_place.get("name", name), lat, lon, location, session
         )
+        if not yelp_biz:
+            phone = g_details.get("formatted_phone_number") or g_details.get("international_phone_number")
+            yelp_biz = search_yelp_by_phone(phone or "", session)
         biz_id = yelp_biz.get("id")
         if biz_id:
             yelp_details = get_yelp_details(biz_id, session)
@@ -135,6 +164,10 @@ def enrich_restaurant(name: str, location: str) -> dict[str, Any]:
             "website": yelp_details.get("url"),
             "delivery": "delivery" in (yelp_details.get("transactions") or []),
             "review_count": yelp_details.get("review_count"),
+            "rating": yelp_details.get("rating"),
+            "price": yelp_details.get("price"),
+            "phone": yelp_details.get("display_phone"),
+            "is_closed": yelp_details.get("is_closed"),
         }
 
         return {


### PR DESCRIPTION
## Summary
- enhance Yelp enrichment with Google phone lookup and fallback search by phone
- include more Yelp data (rating, price, phone, closed status)
- document new behavior in README
- update tests for phone fallback

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684af676e134832dab9796537a8b92fb