### PR TITLE
Add environment override test for check_network

### DIFF
--- a/tests/test_network_utils.py
+++ b/tests/test_network_utils.py
@@ -35,3 +35,33 @@ def test_check_network_head(monkeypatch):
     monkeypatch.setattr(requests_stub, "head", dummy_head)
     monkeypatch.setattr(network_utils, "requests", requests_stub)
     assert network_utils.check_network(method="HEAD")
+
+
+def test_check_network_env_overrides(monkeypatch):
+    """check_network should honor environment variable overrides."""
+
+    called = {}
+
+    def dummy_head(url, timeout, allow_redirects):
+        called["url"] = url
+        called["timeout"] = timeout
+        called["allow_redirects"] = allow_redirects
+
+        class Resp:
+            pass
+
+        return Resp()
+
+    monkeypatch.setattr(requests_stub, "head", dummy_head)
+    monkeypatch.setattr(network_utils, "requests", requests_stub)
+
+    monkeypatch.setenv("NETWORK_TEST_URL", "https://example.com/ping")
+    monkeypatch.setenv("NETWORK_TEST_METHOD", "HEAD")
+    monkeypatch.setenv("NETWORK_TEST_TIMEOUT", "11")
+
+    assert network_utils.check_network()
+    assert called == {
+        "url": "https://example.com/ping",
+        "timeout": 11,
+        "allow_redirects": False,
+    }


### PR DESCRIPTION
## Summary
- add a new test case ensuring `check_network` uses `NETWORK_TEST_*` variables

## Testing
- `bash setup_tests.sh`
- `pytest tests/test_network_utils.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684b0632cd88832da4388d2ed82ed616