### PR TITLE
Add docstring for toast_leads module

### DIFF
--- a/restaurants/toast_leads.py
+++ b/restaurants/toast_leads.py
@@ -1,3 +1,9 @@
+"""Fetch restaurant leads from Google Places for the Toast POS team.
+
+ZIP codes are read from ``toast_zips.txt`` and new results are written to
+``olympia_toast_smb_<timestamp>.csv``.
+"""
+
 import json
 import csv
 import time


### PR DESCRIPTION
## Summary
- document the toast leads fetcher at the top of the module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b088042e0832d9ec150573c12e76e