### PR TITLE
Ensure NETWORK_TEST_METHOD validation

### DIFF
--- a/restaurants/network_utils.py
+++ b/restaurants/network_utils.py
@@ -20,7 +20,11 @@ def check_network(
     restricted networks.
     """
     url = os.getenv("NETWORK_TEST_URL", url)
+    default_method = method
     method = os.getenv("NETWORK_TEST_METHOD", method)
+    if method.upper() not in ("GET", "HEAD"):
+        logging.error("Invalid NETWORK_TEST_METHOD value: %s", method)
+        method = default_method
     timeout_env = os.getenv("NETWORK_TEST_TIMEOUT")
     if timeout_env:
         try:

--- a/tests/test_network_utils.py
+++ b/tests/test_network_utils.py
@@ -65,3 +65,33 @@ def test_check_network_env_overrides(monkeypatch):
         "timeout": 11,
         "allow_redirects": False,
     }
+
+
+def test_check_network_invalid_env_method(monkeypatch):
+    """Invalid NETWORK_TEST_METHOD should fall back to the default."""
+
+    called = {}
+
+    def dummy_get(url, timeout, allow_redirects):
+        called["method"] = "GET"
+
+        class Resp:
+            pass
+
+        return Resp()
+
+    monkeypatch.setattr(requests_stub, "get", dummy_get)
+    monkeypatch.setattr(network_utils, "requests", requests_stub)
+
+    errors = []
+
+    def dummy_error(msg, *args):
+        errors.append(msg % args)
+
+    monkeypatch.setattr(network_utils.logging, "error", dummy_error)
+
+    monkeypatch.setenv("NETWORK_TEST_METHOD", "POST")
+
+    assert network_utils.check_network()
+    assert called["method"] == "GET"
+    assert any("Invalid NETWORK_TEST_METHOD" in e for e in errors)


### PR DESCRIPTION
## Summary
- check that NETWORK_TEST_METHOD is `GET` or `HEAD`
- log an error when invalid and fall back to the default method
- add unit test for invalid NETWORK_TEST_METHOD

## Testing
- `./setup_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684b0976dfdc832dbfbc94e5990b4cb9