### PR TITLE
Add Yelp enrichment to refresh workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ By default `refresh_restaurants.py` loads ZIP codes from `toast_zips.txt` using
 `restaurants.config.load_zip_codes`. The file includes many ZIP codes across the
 Olympia area. You can pass `--zips` with any additional ZIP codes (e.g.
 `--zips 98502`). The script displays a progress bar via `tqdm` as it fetches
-Google results.
-Pass `--strict-zips` to drop any fetched rows whose `Zip Code` isn't in the
+Google results. After loading the results it automatically enriches each row
+with Yelp data when `YELP_API_KEY` is set. Pass `--no-yelp` to skip this step.
+Use `--strict-zips` to drop any fetched rows whose `Zip Code` isn't in the
 provided list. This is useful when Google returns nearby results outside the
 desired ZIP codes.
 
@@ -74,8 +75,10 @@ data and fetching Toast leads.
 
 ## Yelp enrichment
 
-Run `google_yelp_enrich.py` to supplement Google Places rows with Yelp ratings and
-categories. The script searches Yelp by the restaurant name and city and scans
+`refresh-restaurants` now enriches Google Places rows with Yelp ratings and
+categories automatically when `YELP_API_KEY` is set. You can still run
+`google_yelp_enrich.py` manually if desired. The script searches Yelp by the
+restaurant name and city and scans
 up to five candidates. `rapidfuzz.fuzz.token_set_ratio` picks the best match and
 only applies it when the score meets the `YELP_MATCH_THRESHOLD` (60 by default).
 When that fails the utility fetches the place's phone number from Google and
@@ -84,8 +87,8 @@ marked as `FAIL`. The summary section now includes rating, price tier, phone and
 closed status in addition to the list of cuisines.
 
 Ensure the `dela.sqlite` database exists (created by `refresh_restaurants.py`)
-and that `YELP_API_KEY` is set before running. If either is missing the script
-exits with a message explaining what is required.
+and that `YELP_API_KEY` is set before running. Without the key the refresh
+command will skip enrichment unless you pass `--no-yelp`.
 
 Set `YELP_DEBUG=1` to print debug information about failed lookups, including
 all Yelp candidate names returned for each query.

--- a/restaurants/refresh_restaurants.py
+++ b/restaurants/refresh_restaurants.py
@@ -14,6 +14,7 @@ from restaurants.utils import setup_logging
 from restaurants import loader
 from restaurants.config import GOOGLE_API_KEY, load_zip_codes
 from restaurants.settings import FETCHERS
+from restaurants import google_yelp_enrich
 
 # Aggregate store for fetched restaurant rows
 smb_restaurants_data: list[dict] = []
@@ -30,6 +31,11 @@ def main(argv: list[str] | None = None) -> None:
         "--strict-zips",
         action="store_true",
         help="Only keep rows whose Zip Code matches the provided list",
+    )
+    parser.add_argument(
+        "--no-yelp",
+        action="store_true",
+        help="Skip Yelp enrichment step",
     )
     args = parser.parse_args(argv)
 
@@ -64,6 +70,9 @@ def main(argv: list[str] | None = None) -> None:
 
     csv_path = pathlib.Path(out_csv)
     loader.load(csv_path)
+
+    if not args.no_yelp:
+        google_yelp_enrich.yelp_enrich_all()
 
     conn = sqlite3.connect(loader.DB_PATH)
     df_db = pd.read_sql_query("SELECT * FROM places", conn)


### PR DESCRIPTION
## Summary
- enrich all restaurants with Yelp using new helper
- run Yelp enrichment in refresh-restaurants and allow skipping with `--no-yelp`
- document Yelp integration in README
- test new database update logic and CLI flag

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b0b7a3d68832da4af3a94787104e2