### PR TITLE
Add GPV projection fetcher and DB support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This project collects restaurant information for ZIP codes around Olympia, Washi
   Five Guys and Dave & Buster's.
 - **Government CSV importer** *(disabled)* for Washington health and Thurston County license data.
 - **OpenStreetMap fetcher** *(disabled)* for additional restaurant listings.
+- **GPV projection fetcher** *(optional)* reads projected visitor volume from a
+  CSV and adds a `GPV Projection` column.
 - **Deduplication routine** that merges results from all sources while prioritizing Google Places SMB entries.
 - **Automatic social link extraction** scrapes each website for Facebook and Instagram URLs.
 - **Network check** using a lightweight GET request to gracefully skip online

--- a/restaurants/fetchers/__init__.py
+++ b/restaurants/fetchers/__init__.py
@@ -2,10 +2,12 @@ from .base import BaseFetcher
 from .google_places import GooglePlacesFetcher
 from .gov_csv import GovCsvFetcher
 from .osm import OsmFetcher
+from .gpv import GpvFetcher
 
 __all__ = [
     "BaseFetcher",
     "GooglePlacesFetcher",
     "GovCsvFetcher",
     "OsmFetcher",
+    "GpvFetcher",
 ]

--- a/restaurants/fetchers/gpv.py
+++ b/restaurants/fetchers/gpv.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import os
+import logging
+import pandas as pd
+
+from .base import BaseFetcher
+
+
+class GpvFetcher(BaseFetcher):
+    """Fetch GPV projection data from a CSV file."""
+
+    CSV_ENV = "GPV_CSV_PATH"
+
+    def fetch(self, zip_codes: list[str], **opts) -> list[dict]:
+        path = os.getenv(self.CSV_ENV)
+        if not path or not os.path.exists(path):
+            logging.error("GPV CSV not found; set %s", self.CSV_ENV)
+            return []
+
+        df = pd.read_csv(path)
+        if "Place ID" not in df.columns:
+            logging.error("GPV CSV missing 'Place ID' column")
+            return []
+        if "GPV Projection" not in df.columns:
+            logging.error("GPV CSV missing 'GPV Projection' column")
+            return []
+
+        df = df[["Place ID", "GPV Projection"]].copy()
+        df["source"] = "gpv_projection"
+        return df.to_dict(orient="records")
+

--- a/restaurants/loader.py
+++ b/restaurants/loader.py
@@ -54,7 +54,8 @@ CREATE TABLE IF NOT EXISTS places (
   yelp_primary_cuisine TEXT,
   yelp_category_titles TEXT,
   facebook_url TEXT,
-  instagram_url TEXT
+  instagram_url TEXT,
+  gpv_projection REAL
 );
 """
 )
@@ -82,6 +83,7 @@ RENAMES = {
     "source": "source",
     "facebook_url": "facebook_url",
     "instagram_url": "instagram_url",
+    "GPV Projection": "gpv_projection",
 }
 
 # --------------------------------------------------------------------------- #
@@ -110,6 +112,8 @@ def ensure_db() -> sqlite3.Connection:
         cur.execute("ALTER TABLE places ADD COLUMN facebook_url TEXT")
     if "instagram_url" not in cols:
         cur.execute("ALTER TABLE places ADD COLUMN instagram_url TEXT")
+    if "gpv_projection" not in cols:
+        cur.execute("ALTER TABLE places ADD COLUMN gpv_projection REAL")
     conn.commit()
     return conn
 

--- a/restaurants/refresh_restaurants.py
+++ b/restaurants/refresh_restaurants.py
@@ -67,7 +67,7 @@ def main(argv: list[str] | None = None) -> None:
         return
 
     df = pd.DataFrame(smb_restaurants_data)
-    for col in ["facebook_url", "instagram_url"]:
+    for col in ["facebook_url", "instagram_url", "GPV Projection"]:
         if col not in df.columns:
             df[col] = None
     if args.strict_zips and "Zip Code" in df.columns:

--- a/restaurants/settings.py
+++ b/restaurants/settings.py
@@ -1,10 +1,16 @@
 """Application settings for restaurant fetchers."""
 
-from restaurants.fetchers import GooglePlacesFetcher, GovCsvFetcher, OsmFetcher
+from restaurants.fetchers import (
+    GooglePlacesFetcher,
+    GovCsvFetcher,
+    OsmFetcher,
+    GpvFetcher,
+)
 
 # (fetcher class, enabled)
 FETCHERS = [
     (GooglePlacesFetcher, True),
     (GovCsvFetcher, False),
     (OsmFetcher, False),
+    (GpvFetcher, False),
 ]

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -45,6 +45,7 @@ def test_ensure_db_adds_yelp_columns_fresh_db(tmp_path, monkeypatch):
         "yelp_category_titles",
         "facebook_url",
         "instagram_url",
+        "gpv_projection",
     } <= cols
 
 
@@ -70,6 +71,7 @@ def test_ensure_db_adds_yelp_columns_existing_db(tmp_path, monkeypatch):
         "yelp_category_titles",
         "facebook_url",
         "instagram_url",
+        "gpv_projection",
     } <= cols
 
 
@@ -95,6 +97,7 @@ def test_ensure_db_updates_partial_schema(tmp_path, monkeypatch):
         "yelp_category_titles",
         "facebook_url",
         "instagram_url",
+        "gpv_projection",
     } <= cols
 
 


### PR DESCRIPTION
## Summary
- add `GpvFetcher` and register it in the fetcher package
- optionally enable `GpvFetcher` via `settings.FETCHERS`
- store GPV projections in the database and default to `None` when missing
- include GPV column when refreshing restaurant data
- update tests for new column
- document the new fetcher in the README

## Testing
- `pip install -e .`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b301e83dc832dbcba3ccc857cef0e