### PR TITLE
Improve README testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ pip install -r requirements-dev.txt
 pytest
 ```
 
+Run `pytest -s` to see logging and progress messages during the suite. The
+`-s` flag disables output capturing so `tqdm` progress bars and other prints are
+visible.
+
 The dev file includes `pytest`, `mypy` and type stubs. It also pulls in the
 packages from `requirements.txt` so a single install command prepares the
 environment. For convenience you can run `./setup_tests.sh` which installs the


### PR DESCRIPTION
## Summary
- update the README's Tests section
- describe using `pytest -s` to show logs and progress

## Testing
- `./setup_tests.sh`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b71e2ccc8832d9615ac823a919188